### PR TITLE
Config for kjøring av appen lokalt

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,2 @@
+management.server.port=8083
+server.port=8084


### PR DESCRIPTION
## Hvorfor? 

SKIP-configen er satt til å være port 8080/81. Det er også portene backend-tjenesten kjører på, noe som da skaper konflikt ved lokal kjøring.

## Løsning

Legger til `application-local.properties` som overrider porter ved lokal kjøring for krypto-tjenesten. 