### PR TITLE
Add global error handling for decrypt

### DIFF
--- a/src/main/kotlin/crypto_service/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/crypto_service/exception/GlobalExceptionHandler.kt
@@ -11,13 +11,15 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @ControllerAdvice
 class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
-
     @ExceptionHandler
-    fun handleUncaughtException(ex: Exception, request: WebRequest): ResponseEntity<ErrorResponse> {
+    fun handleUncaughtException(
+        ex: Exception,
+        request: WebRequest,
+    ): ResponseEntity<ErrorResponse> {
         logger.warn(ex.message, ex)
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ErrorResponse.create(ex, HttpStatus.INTERNAL_SERVER_ERROR, "Exception message: ${ex.message}" ))
+            .body(ErrorResponse.create(ex, HttpStatus.INTERNAL_SERVER_ERROR, "Exception message: ${ex.message}"))
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -27,6 +29,14 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ErrorResponse.create(ex, HttpStatus.INTERNAL_SERVER_ERROR, "Exception message: ${ex.message}"))
+    }
 
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(SOPSDecryptionException::class)
+    fun handleSopsDecryptionException(ex: SOPSDecryptionException): ResponseEntity<ErrorResponse> {
+        logger.error(ex.message, ex)
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse.create(ex, HttpStatus.INTERNAL_SERVER_ERROR, "Exception message: ${ex.message}"))
     }
 }

--- a/src/main/kotlin/crypto_service/service/DecryptionService.kt
+++ b/src/main/kotlin/crypto_service/service/DecryptionService.kt
@@ -2,17 +2,13 @@ package crypto_service.service
 
 import crypto_service.exception.SOPSDecryptionException
 import crypto_service.model.GCPAccessToken
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
 @Service
 class DecryptionService {
-
     private val processBuilder = ProcessBuilder().redirectErrorStream(true)
-
-    private val logger = LoggerFactory.getLogger(DecryptionService::class.java)
 
     fun decrypt(
         ciphertext: String,
@@ -30,25 +26,23 @@ class DecryptionService {
                         EXECUTION_STATUS_OK -> result
 
                         else -> {
-                            logger.error("IOException from decrypting yaml with error code ${exitValue()}: $result")
                             throw SOPSDecryptionException(
-                                message = result,
+                                message = "Decrypting message failed with error: $result",
                             )
                         }
                     }
                 }
         } catch (e: Exception) {
-            logger.error("Decrypting failed.", e)
             throw e
         }
     }
 
     private fun toDecryptionCommand(
         accessToken: String,
-        sopsPrivateKey: String
+        sopsPrivateKey: String,
     ): List<String> =
-        sopsCmd + ageSecret(sopsPrivateKey) + decrypt + inputTypeYaml + outputTypeJson + inputFile + gcpAccessToken(
-            accessToken
-        )
-
+        sopsCmd + ageSecret(sopsPrivateKey) + decrypt + inputTypeYaml + outputTypeJson + inputFile +
+            gcpAccessToken(
+                accessToken,
+            )
 }


### PR DESCRIPTION
## Hvorfor?

Det fantes ingen global errorhåndtering for dekrypteringsfeil, så la til det. Ryddet da også opp i hvordan feil ble logget, slik at vi unngår duplikat logging.