### PR TITLE
Rename pakkenavn til å følge ktlint regler

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,0 @@
-[*.{kt,kts}]
-ktlint_standard_package-name = disabled

--- a/src/main/kotlin/cryptoservice/CryptoServiceApplication.kt
+++ b/src/main/kotlin/cryptoservice/CryptoServiceApplication.kt
@@ -1,4 +1,4 @@
-package crypto_service
+package cryptoservice
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/src/main/kotlin/cryptoservice/controller/CryptoController.kt
+++ b/src/main/kotlin/cryptoservice/controller/CryptoController.kt
@@ -1,9 +1,9 @@
-package crypto_service.controller
+package cryptoservice.controller
 
-import crypto_service.controller.models.EncryptionRequest
-import crypto_service.model.GCPAccessToken
-import crypto_service.service.DecryptionService
-import crypto_service.service.EncryptionService
+import cryptoservice.controller.models.EncryptionRequest
+import cryptoservice.model.GCPAccessToken
+import cryptoservice.service.DecryptionService
+import cryptoservice.service.EncryptionService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping

--- a/src/main/kotlin/cryptoservice/controller/models/EncryptionRequest.kt
+++ b/src/main/kotlin/cryptoservice/controller/models/EncryptionRequest.kt
@@ -1,4 +1,4 @@
-package crypto_service.controller.models
+package cryptoservice.controller.models
 
 data class EncryptionRequest(
     val text: String,

--- a/src/main/kotlin/cryptoservice/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/cryptoservice/exception/GlobalExceptionHandler.kt
@@ -1,7 +1,7 @@
-package crypto_service.exception
+package cryptoservice.exception
 
-import crypto_service.exception.exceptions.SOPSDecryptionException
-import crypto_service.exception.exceptions.SopsEncryptionException
+import cryptoservice.exception.exceptions.SOPSDecryptionException
+import cryptoservice.exception.exceptions.SopsEncryptionException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.ErrorResponse

--- a/src/main/kotlin/cryptoservice/exception/exceptions/SopsEncryptionException.kt
+++ b/src/main/kotlin/cryptoservice/exception/exceptions/SopsEncryptionException.kt
@@ -1,4 +1,4 @@
-package crypto_service.exception.exceptions
+package cryptoservice.exception.exceptions
 
 data class SopsEncryptionException(
     override val message: String,

--- a/src/main/kotlin/cryptoservice/model/GCPAccessToken.kt
+++ b/src/main/kotlin/cryptoservice/model/GCPAccessToken.kt
@@ -1,4 +1,4 @@
-package crypto_service.model
+package cryptoservice.model
 
 data class GCPAccessToken(val value: String)
 

--- a/src/main/kotlin/cryptoservice/service/DecryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/DecryptionService.kt
@@ -1,7 +1,7 @@
-package crypto_service.service
+package cryptoservice.service
 
-import crypto_service.exception.exceptions.SOPSDecryptionException
-import crypto_service.model.GCPAccessToken
+import cryptoservice.exception.exceptions.SOPSDecryptionException
+import cryptoservice.model.GCPAccessToken
 import org.springframework.stereotype.Service
 import java.io.BufferedReader
 import java.io.InputStreamReader

--- a/src/main/kotlin/cryptoservice/service/EncryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/EncryptionService.kt
@@ -1,8 +1,8 @@
-package crypto_service.service
+package cryptoservice.service
 
-import crypto_service.exception.exceptions.SopsEncryptionException
-import crypto_service.model.GCPAccessToken
-import crypto_service.model.sensor
+import cryptoservice.exception.exceptions.SopsEncryptionException
+import cryptoservice.model.GCPAccessToken
+import cryptoservice.model.sensor
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.io.BufferedReader

--- a/src/main/kotlin/cryptoservice/service/Utils.kt
+++ b/src/main/kotlin/cryptoservice/service/Utils.kt
@@ -1,4 +1,4 @@
-package crypto_service.service
+package cryptoservice.service
 
 val sopsCmd: List<String> = listOf("sops")
 val encrypt: List<String> = listOf("encrypt")


### PR DESCRIPTION
## Hvorfor?

Ettersom det er en del folk innom disse repoene innførte vi helt basic linting, men hadde disablet én regel. Vi tenker at det er greit ikke ha noe custom, for å holde det ryddigst mulig. 

## Hva? 
Ktlint liker ikke understrek i pakkenavn, renamer derfor pakken og fjerner at vi disabler denne reglen. 