### PR TITLE
sopsAgeKey som miljøvariabel

### DIFF
--- a/src/main/kotlin/cryptoservice/controller/CryptoController.kt
+++ b/src/main/kotlin/cryptoservice/controller/CryptoController.kt
@@ -20,9 +20,9 @@ class CryptoController(
     val decryptionService: DecryptionService,
 ) {
     /* Dette er slik vi egentlig burde gjøre dekryptering, for at crypto-service kan være helt uavhengig av
-    * tjeneste som kaller den. Ettersom SOPS + age er avhengig av at det enten finnes en keys.txt-fil eller
-    * at `SOPS_AGE_KEY` er satt som miljøvariabel, så kan vi ikke gjøre det på denne måten enda. Ettersom det
-    * bare er risc-scorecard-backend som bruker crypto-service er ikke dette et reelt problem enda.
+    * tjenesten som kaller den. Ettersom SOPS + age er avhengig av at det enten finnes en keys.txt-fil eller
+    * at `SOPS_AGE_KEY` er satt som miljøvariabel, så kan vi ikke gjøre det på denne måten enda. Det er mulig dette
+    * kan bli støttet i fremtiden ifølge dokumentasjonen til SOPS.
     * */
     @GetMapping("/decrypt")
     fun decrypt(

--- a/src/main/kotlin/cryptoservice/controller/CryptoController.kt
+++ b/src/main/kotlin/cryptoservice/controller/CryptoController.kt
@@ -24,8 +24,8 @@ class CryptoController(
      * at `SOPS_AGE_KEY` er satt som miljøvariabel, så kan vi ikke gjøre det på denne måten enda. Det er mulig dette
      * kan bli støttet i fremtiden ifølge dokumentasjonen til SOPS.
      */
-    @GetMapping("/decrypt")
-    fun decrypt(
+    @GetMapping("/decrypt-with-age-key")
+    fun decryptWithAgeKey(
         @RequestHeader gcpAccessToken: String,
         @RequestHeader agePrivateKey: String,
         @RequestBody cipherText: String,

--- a/src/main/kotlin/cryptoservice/controller/CryptoController.kt
+++ b/src/main/kotlin/cryptoservice/controller/CryptoController.kt
@@ -20,18 +20,17 @@ class CryptoController(
     val decryptionService: DecryptionService,
 ) {
     /* Dette er slik vi egentlig burde gjøre dekryptering, for at crypto-service kan være helt uavhengig av
-    * tjenesten som kaller den. Ettersom SOPS + age er avhengig av at det enten finnes en keys.txt-fil eller
-    * at `SOPS_AGE_KEY` er satt som miljøvariabel, så kan vi ikke gjøre det på denne måten enda. Det er mulig dette
-    * kan bli støttet i fremtiden ifølge dokumentasjonen til SOPS.
-    * */
+     * tjenesten som kaller den. Ettersom SOPS + age er avhengig av at det enten finnes en keys.txt-fil eller
+     * at `SOPS_AGE_KEY` er satt som miljøvariabel, så kan vi ikke gjøre det på denne måten enda. Det er mulig dette
+     * kan bli støttet i fremtiden ifølge dokumentasjonen til SOPS.
+     */
     @GetMapping("/decrypt")
     fun decrypt(
         @RequestHeader gcpAccessToken: String,
         @RequestHeader agePrivateKey: String,
         @RequestBody cipherText: String,
     ): ResponseEntity<String> {
-
-        //Bruk decryptionService.decrypt() og legg til agePrivateKey som inputparameter.
+        // Bruk decryptionService.decrypt() og legg til agePrivateKey som inputparameter.
 
         return ResponseEntity("Not implemented yet", HttpStatus.NOT_IMPLEMENTED)
     }

--- a/src/main/kotlin/cryptoservice/controller/CryptoController.kt
+++ b/src/main/kotlin/cryptoservice/controller/CryptoController.kt
@@ -4,6 +4,7 @@ import cryptoservice.controller.models.EncryptionRequest
 import cryptoservice.model.GCPAccessToken
 import cryptoservice.service.DecryptionService
 import cryptoservice.service.EncryptionService
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -18,13 +19,29 @@ class CryptoController(
     val encryptionService: EncryptionService,
     val decryptionService: DecryptionService,
 ) {
+    /* Dette er slik vi egentlig burde gjøre dekryptering, for at crypto-service kan være helt uavhengig av
+    * tjeneste som kaller den. Ettersom SOPS + age er avhengig av at det enten finnes en keys.txt-fil eller
+    * at `SOPS_AGE_KEY` er satt som miljøvariabel, så kan vi ikke gjøre det på denne måten enda. Ettersom det
+    * bare er risc-scorecard-backend som bruker crypto-service er ikke dette et reelt problem enda.
+    * */
     @GetMapping("/decrypt")
     fun decrypt(
         @RequestHeader gcpAccessToken: String,
         @RequestHeader agePrivateKey: String,
         @RequestBody cipherText: String,
     ): ResponseEntity<String> {
-        val decryptedString = decryptionService.decrypt(cipherText, GCPAccessToken(gcpAccessToken), agePrivateKey)
+
+        //Bruk decryptionService.decrypt() og legg til agePrivateKey som inputparameter.
+
+        return ResponseEntity("Not implemented yet", HttpStatus.NOT_IMPLEMENTED)
+    }
+
+    @GetMapping("/decrypt")
+    fun decrypt(
+        @RequestHeader gcpAccessToken: String,
+        @RequestBody cipherText: String,
+    ): ResponseEntity<String> {
+        val decryptedString = decryptionService.decrypt(cipherText, GCPAccessToken(gcpAccessToken))
 
         return ResponseEntity.ok().body(decryptedString)
     }

--- a/src/main/kotlin/cryptoservice/service/DecryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/DecryptionService.kt
@@ -2,22 +2,24 @@ package cryptoservice.service
 
 import cryptoservice.exception.exceptions.SOPSDecryptionException
 import cryptoservice.model.GCPAccessToken
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
 @Service
-class DecryptionService {
+class DecryptionService(
+    @Value("\${sops.ageKey}") val ageKey: String,
+) {
     private val processBuilder = ProcessBuilder().redirectErrorStream(true)
 
     fun decrypt(
         ciphertext: String,
         gcpAccessToken: GCPAccessToken,
-        agePrivateKey: String,
     ): String {
         return try {
             processBuilder
-                .command(toDecryptionCommand(gcpAccessToken.value, agePrivateKey))
+                .command(toDecryptionCommand(gcpAccessToken.value, ageKey))
                 .start()
                 .run {
                     outputStream.buffered().also { it.write(ciphertext.toByteArray()) }.close()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=prometheus,health
+
+sops.ageKey=${SOPS_AGE_KEY}


### PR DESCRIPTION
## Hvorfor?

Dekryptering vha sops+age krever enten en keys.txt-fil med nøkkelen, eller at den er satt som en miljøvariabel med navn SOPS_AGE_KEY. [Se dokumentajson](https://github.com/getsops/sops?tab=readme-ov-file#id7). 

Lar endepunktet som tar imot agePrivateKey ligge, ettersom det er det vi _egentlig_ vil bruke. Skrev en kommentar om hvorfor vi ikke kan bruke det enda. Den kan godt fjernes, men da burde vi finne et annet sted å persistere denne infoen!