### PR TITLE
Fjern age-flagg fra decrypt-command

### DIFF
--- a/src/main/kotlin/cryptoservice/service/DecryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/DecryptionService.kt
@@ -36,11 +36,9 @@ class DecryptionService {
         }
     }
 
-    private fun toDecryptionCommand(
-        accessToken: String,
-    ): List<String> =
+    private fun toDecryptionCommand(accessToken: String): List<String> =
         sopsCmd + decrypt + inputTypeYaml + outputTypeJson + inputFile +
-                gcpAccessToken(
-                    accessToken,
-                )
+            gcpAccessToken(
+                accessToken,
+            )
 }

--- a/src/main/kotlin/cryptoservice/service/DecryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/DecryptionService.kt
@@ -2,15 +2,12 @@ package cryptoservice.service
 
 import cryptoservice.exception.exceptions.SOPSDecryptionException
 import cryptoservice.model.GCPAccessToken
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
 @Service
-class DecryptionService(
-    @Value("\${sops.ageKey}") val ageKey: String,
-) {
+class DecryptionService {
     private val processBuilder = ProcessBuilder().redirectErrorStream(true)
 
     fun decrypt(
@@ -19,7 +16,7 @@ class DecryptionService(
     ): String {
         return try {
             processBuilder
-                .command(toDecryptionCommand(gcpAccessToken.value, ageKey))
+                .command(toDecryptionCommand(gcpAccessToken.value))
                 .start()
                 .run {
                     outputStream.buffered().also { it.write(ciphertext.toByteArray()) }.close()
@@ -41,10 +38,9 @@ class DecryptionService(
 
     private fun toDecryptionCommand(
         accessToken: String,
-        sopsPrivateKey: String,
     ): List<String> =
-        sopsCmd + ageSecret(sopsPrivateKey) + decrypt + inputTypeYaml + outputTypeJson + inputFile +
-            gcpAccessToken(
-                accessToken,
-            )
+        sopsCmd + decrypt + inputTypeYaml + outputTypeJson + inputFile +
+                gcpAccessToken(
+                    accessToken,
+                )
 }

--- a/src/main/kotlin/cryptoservice/service/Utils.kt
+++ b/src/main/kotlin/cryptoservice/service/Utils.kt
@@ -13,5 +13,3 @@ val inputFile: List<String> = listOf("/dev/stdin")
 const val EXECUTION_STATUS_OK = 0
 
 fun gcpAccessToken(accessToken: String): List<String> = listOf("--gcp-access-token", accessToken)
-
-fun ageSecret(sopsPrivateKey: String): List<String> = listOf("--age", sopsPrivateKey)


### PR DESCRIPTION
## Hvorfor?

For en decrypt-kommand vil SOPS se etter ageKey på en gitt path eller som en miljøvariabel (ref #18), og det har dermed ingen effekt å sette `--age` i kommandoen vi bygger opp. Tenker derfor å fjerne den for å unngå misforståelser. 

### NB
En ting vi må ha i bakhodet er at bruk av `ageKey` for dekryptering ikke kan leses utifra koden, og kan være vanskelig for nye utviklere å vite dersom de ikke har god kjennskap til hvordan SOPS fungerer🧐 