### PR TITLE
Feature/egne env vars for kommandoer

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -106,22 +106,60 @@ jobs:
         with:
           image_url: ${{ needs.build.outputs.image_url }}
 
-  deploy:
-    name: Deploy to ATGCP1-PROD
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  sandbox-deploy-argo:
+    name: Deploy to sandbox
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: sandbox
+    permissions:
+      id-token: write
     steps:
-      - name: Checkout apps-repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: kartverket/skvis-apps
+          identity: crypto-service
+      - name: Checkout skvis-apps
+        uses: actions/checkout@v4
         with:
           repository: kartverket/skvis-apps
           ref: main
-          token: ${{ secrets.ARGO_PAT }}
+          token: ${{ steps.octo-sts.outputs.token }}
+      - name: Update version
+        run: |
+          echo "\"${{ needs.build.outputs.image_url }}\"" > "env/atgcp1-sandbox/ros-plugin-main/${{ env.ARGO_VERSION_FILE }}"
+          git config --global user.email "noreply@kartverket.no"
+          git config --global user.name "Backstage Plugin Risk Scorecard Backend CI"
+          git commit -am "Update ros-backend ${{ env.ARGO_VERSION_FILE }}"
+          git push
+
+  prod-deploy-argo:
+    name: Deploy to prod
+    if: github.ref == 'refs/heads/main'
+    needs: [build, sandbox-deploy-argo]
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    permissions:
+      id-token: write
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: kartverket/skvis-apps
+          identity: crypto-service
+      - name: Checkout skvis-apps
+        uses: actions/checkout@v4
+        with:
+          repository: kartverket/skvis-apps
+          ref: main
+          token: ${{ steps.octo-sts.outputs.token }}
       - name: Update version
         run: |
           echo "\"${{ needs.build.outputs.image_url }}\"" > "env/atgcp1-prod/ros-plugin-main/${{ env.ARGO_VERSION_FILE }}"
           git config --global user.email "noreply@kartverket.no"
-          git config --global user.name "ROS Crypto Service CI"
-          git commit -am "Update ${{ env.ARGO_VERSION_FILE }}"
+          git config --global user.name "Backstage Plugin Risk Scorecard Backend CI"
+          git commit -am "Update ros-backend ${{ env.ARGO_VERSION_FILE }}"
           git push

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ gradle-app.setting
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+
+# Idea
+.idea/*

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="3fb14dec-05f0-4328-87e3-2683b6041a04" name="Changes" comment="test: legg til to enkle endepunkter for test">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.run/Local Server.run.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.run/Local Server.run.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/kotlinc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/kotlinc.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/kotlin/cryptoservice/controller/CryptoController.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/kotlin/cryptoservice/controller/CryptoController.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.properties" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -31,6 +31,11 @@
               <path>
                 <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
                 <item name="backstage-plugin-risk-scorecard-crypto-service" type="f1a62948:ProjectNode" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="backstage-plugin-risk-scorecard-crypto-service" type="f1a62948:ProjectNode" />
+                <item name="Run Configurations" type="7b0102dc:RunConfigurationsNode" />
               </path>
             </expand>
             <select />
@@ -76,45 +81,45 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Downloaded.Files.Path.Enabled&quot;: &quot;false&quot;,
-    &quot;Gradle.Build backstage-plugin-risk-crypto-service.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.EncryptionServiceTest.encrypt data.executor&quot;: &quot;Debug&quot;,
-    &quot;HTTP Request.generated-requests | #2.executor&quot;: &quot;Run&quot;,
-    &quot;HTTP Request.generated-requests | #3.executor&quot;: &quot;Run&quot;,
-    &quot;HTTP Request.generated-requests | #4.executor&quot;: &quot;Run&quot;,
-    &quot;HTTP Request.generated-requests | #6.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.EncryptionServiceTest.encrypt works.executor&quot;: &quot;Debug&quot;,
-    &quot;Repository.Attach.Annotations&quot;: &quot;false&quot;,
-    &quot;Repository.Attach.JavaDocs&quot;: &quot;false&quot;,
-    &quot;Repository.Attach.Sources&quot;: &quot;false&quot;,
-    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
-    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
-    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
-    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;Spring Boot.Local Server.executor&quot;: &quot;Run&quot;,
-    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary&quot;: &quot;JUnit5&quot;,
-    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5&quot;: &quot;&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;chore/sjekk-med-ping&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/maren/Documents/code/ros/backstage-plugin-risk-crypto-service&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;org.rust.first.attach.projects&quot;: &quot;true&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.keymap&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Downloaded.Files.Path.Enabled": "false",
+    "Gradle.Build backstage-plugin-risk-crypto-service.executor": "Run",
+    "Gradle.EncryptionServiceTest.encrypt data.executor": "Debug",
+    "HTTP Request.generated-requests | #2.executor": "Run",
+    "HTTP Request.generated-requests | #3.executor": "Run",
+    "HTTP Request.generated-requests | #4.executor": "Run",
+    "HTTP Request.generated-requests | #6.executor": "Run",
+    "JUnit.EncryptionServiceTest.encrypt works.executor": "Debug",
+    "Repository.Attach.Annotations": "false",
+    "Repository.Attach.JavaDocs": "false",
+    "Repository.Attach.Sources": "false",
+    "RequestMappingsPanelOrder0": "0",
+    "RequestMappingsPanelOrder1": "1",
+    "RequestMappingsPanelWidth0": "75",
+    "RequestMappingsPanelWidth1": "75",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "Spring Boot.Local Server.executor": "Run",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
+    "git-widget-placeholder": "feature/egne-env-vars-for-kommandoer",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "/Users/maren/Documents/code/ros/backstage-plugin-risk-crypto-service",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "org.rust.first.attach.projects": "true",
+    "settings.editor.selected.configurable": "preferences.sourceCode.Kotlin",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;kotlin-gradle-user-dirs&quot;: [
-      &quot;/Users/maren/.gradle&quot;
+  "keyToStringList": {
+    "kotlin-gradle-user-dirs": [
+      "/Users/maren/.gradle"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CreateTestDialog.Recents.Supers">
       <recent name="" />
@@ -172,19 +177,6 @@
       <option name="MAIN_CLASS_NAME" value="cryptoservice.service.EncryptionServiceTest" />
       <option name="METHOD_NAME" value="encrypt works" />
       <option name="TEST_OBJECT" value="method" />
-      <method v="2">
-        <option name="Make" enabled="true" />
-      </method>
-    </configuration>
-    <configuration default="true" type="JetRunConfigurationType">
-      <module name="backstage-plugin-risk-scorecard-crypto-service" />
-      <method v="2">
-        <option name="Make" enabled="true" />
-      </method>
-    </configuration>
-    <configuration default="true" type="KotlinStandaloneScriptRunConfigurationType">
-      <module name="backstage-plugin-risk-scorecard-crypto-service" />
-      <option name="filePath" />
       <method v="2">
         <option name="Make" enabled="true" />
       </method>

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ FROM eclipse-temurin:21
 
 RUN mkdir -p /app /app/logs /app/tmp
 
-ARG SOPS_AMD64="https://github.com/bekk/sops/releases/download/v1.2/sops-v1.2.linux.amd64"
-ARG SOPS_ARM64="https://github.com/bekk/sops/releases/download/v1.2/sops-v1.2.linux.arm64"
+ARG SOPS_AMD64="https://github.com/bekk/sops/releases/download/v3/sops-v3.linux.amd64"
+ARG SOPS_ARM64="https://github.com/bekk/sops/releases/download/v3/sops-v3.linux.arm64"
 
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "amd64" ]; then \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-#Dette er en test
-hehe
 # backstage-plugin-risk-crypto-service
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+#Dette er en test
+hehe
 # backstage-plugin-risk-crypto-service
 
 

--- a/src/main/kotlin/cryptoservice/controller/CryptoController.kt
+++ b/src/main/kotlin/cryptoservice/controller/CryptoController.kt
@@ -38,9 +38,10 @@ class CryptoController(
     @GetMapping("/decrypt")
     fun decrypt(
         @RequestHeader gcpAccessToken: String,
+        @RequestHeader agePrivateKey: String,
         @RequestBody cipherText: String,
     ): ResponseEntity<String> {
-        val decryptedString = decryptionService.decrypt(cipherText, GCPAccessToken(gcpAccessToken))
+        val decryptedString = decryptionService.decrypt(cipherText, GCPAccessToken(gcpAccessToken), agePrivateKey)
 
         return ResponseEntity.ok().body(decryptedString)
     }

--- a/src/main/kotlin/cryptoservice/service/DecryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/DecryptionService.kt
@@ -17,7 +17,7 @@ class DecryptionService {
     ): String {
         return try {
             processBuilder
-                .command("sh", "-c", "SOPS_AGE_KEY=$sopsAgeKey GOOGLE_CREDENTIALS_ACCESS_TOKEN=${gcpAccessToken.value} sops decrypt --input-type yaml --output-type json /dev/stdin")
+                .command("sh", "-c", "SOPS_AGE_KEY=$sopsAgeKey GOOGLE_OAUTH_ACCESS_TOKEN=${gcpAccessToken.value} sops decrypt --input-type yaml --output-type json /dev/stdin")
                 .start()
                 .run {
                     outputStream.buffered().also { it.write(ciphertext.toByteArray()) }.close()

--- a/src/main/kotlin/cryptoservice/service/DecryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/DecryptionService.kt
@@ -16,7 +16,7 @@ class DecryptionService {
     ): String {
         return try {
             processBuilder
-                .command(toDecryptionCommand(gcpAccessToken.value))
+                .command("sh", "-c", "SOPS_AGE_KEY=\${sopsAgeKey} GOOGLE_CREDENTIALS_ACCESS_TOKEN=${gcpAccessToken.value} sops decrypt --input-type yaml --output-type json /dev/stdin")
                 .start()
                 .run {
                     outputStream.buffered().also { it.write(ciphertext.toByteArray()) }.close()
@@ -35,10 +35,4 @@ class DecryptionService {
             throw e
         }
     }
-
-    private fun toDecryptionCommand(accessToken: String): List<String> =
-        sopsCmd + decrypt + inputTypeYaml + outputTypeJson + inputFile +
-            gcpAccessToken(
-                accessToken,
-            )
 }

--- a/src/main/kotlin/cryptoservice/service/DecryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/DecryptionService.kt
@@ -13,10 +13,11 @@ class DecryptionService {
     fun decrypt(
         ciphertext: String,
         gcpAccessToken: GCPAccessToken,
+        sopsAgeKey: String
     ): String {
         return try {
             processBuilder
-                .command("sh", "-c", "SOPS_AGE_KEY=\${sopsAgeKey} GOOGLE_CREDENTIALS_ACCESS_TOKEN=${gcpAccessToken.value} sops decrypt --input-type yaml --output-type json /dev/stdin")
+                .command("sh", "-c", "SOPS_AGE_KEY=$sopsAgeKey GOOGLE_CREDENTIALS_ACCESS_TOKEN=${gcpAccessToken.value} sops decrypt --input-type yaml --output-type json /dev/stdin")
                 .start()
                 .run {
                     outputStream.buffered().also { it.write(ciphertext.toByteArray()) }.close()

--- a/src/main/kotlin/cryptoservice/service/EncryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/EncryptionService.kt
@@ -23,7 +23,6 @@ class EncryptionService {
     ): String {
         return try {
             val tempFile = File.createTempFile("sopsConfig-$riScId-${System.currentTimeMillis()}", ".yaml")
-            println("Temporary file created here: ${tempFile.absolutePath}")
             tempFile.writeText(config)
             tempFile.deleteOnExit()
 

--- a/src/main/kotlin/cryptoservice/service/EncryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/EncryptionService.kt
@@ -27,7 +27,7 @@ class EncryptionService {
             tempFile.deleteOnExit()
 
             processBuilder
-                .command("sh", "-c", "GOOGLE_CREDENTIALS_ACCESS_TOKEN=${gcpAccessToken.value} sops --encrypt --input-type json --output-type yaml --config ${tempFile.absolutePath} /dev/stdin")
+                .command("sh", "-c", "GOOGLE_OAUTH_ACCESS_TOKEN=${gcpAccessToken.value} sops --encrypt --input-type json --output-type yaml --config ${tempFile.absolutePath} /dev/stdin")
                 .start()
                 .run {
                     outputStream.buffered().also { it.write(text.toByteArray()) }.close()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,8 @@ management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=prometheus,health
 
 sops.ageKey=${SOPS_AGE_KEY}
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.parallel.config.strategy = dynamic
+junit.jupiter.execution.parallel.config.dynamic.factor = 4

--- a/src/test/kotlin/cryptoservice/service/DecryptionServiceTest.kt
+++ b/src/test/kotlin/cryptoservice/service/DecryptionServiceTest.kt
@@ -1,99 +1,234 @@
 package cryptoservice.service
 
 import cryptoservice.model.GCPAccessToken
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 @Disabled
 class DecryptionServiceTest {
-    val ageKey = "AGE-SECRET-KEY-18TRT94XGD8SC06JSJX5Q9PFFA9XRR0SYKNCVGVLL0EJTS93YJFSQ89A8RP"
-    val invalidAgeKey = ""
-    val sopsFileWithShamir1 = "hei: ENC[AES256_GCM,data:r5bHVoU=,iv:M3YhjRcP7EFSUP5uyjsvUcUVttcnBmM4GPDgdxmUi2A=,tag:UZLHS679wF6jSWAfftz+iQ==,type:str]\n" +
-            "hva: ENC[AES256_GCM,data:jgxACAo=,iv:fCpggS7M/eFNC1ce0Gmy/7wOgS6sF2igcJwqVqxDy80=,tag:GjWX6R+5GXFewJ50HVTZPQ==,type:str]\n" +
-            "sops:\n" +
-            "    shamir_threshold: 1\n" +
-            "    kms: []\n" +
-            "    gcp_kms:\n" +
-            "        - resource_id: projects/spire-ros-5lmr/locations/europe-west4/keyRings/rosene-team/cryptoKeys/ros-as-code-2\n" +
-            "          created_at: \"2024-08-06T11:07:17Z\"\n" +
-            "          enc: CiQAMvdImh2ugjR7IPggRIHlAmnsgnkrmJJK7/VYS8RGA+SPlpYSSQAWhPfdQsTdmcTh2qD4Rgd5vW6lkdjUV3Hp/jN1ERDzPfQL4YHa0pcqE4WV1WLXHOBb6rlSet2xdyJcJ2FbrNPkynCl3o4+fg8=\n" +
-            "    azure_kv: []\n" +
-            "    hc_vault: []\n" +
-            "    age:\n" +
-            "        - recipient: age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\n" +
-            "          enc: |\n" +
-            "            -----BEGIN AGE ENCRYPTED FILE-----\n" +
-            "            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvNWtXNDJQY2t5cVJUdEp0\n" +
-            "            MXM5Zk1FTitucWo2VUtORk9ZVzNGNk83TERzCk9RMmx1M2RRNGZsd2JKamlHNmlK\n" +
-            "            YjA0UjNIZTZ4Rk1rMExOcVRLM1FIcWsKLS0tIDY2YWN0d28reWdaTGp4NFUyekcy\n" +
-            "            NjJodGNxRlNNbXdlYjM2Q0h3VWlSV1UKfA5PfjTJxu7fcCIvJV5Wd3KirAz+3Jak\n" +
-            "            68mpwGaD5VisPKhe1TPrJdcZ/QjzmOIqotoKpYmrzsIm6jYQxGUypw==\n" +
-            "            -----END AGE ENCRYPTED FILE-----\n" +
-            "    lastmodified: \"2024-08-06T11:07:18Z\"\n" +
-            "    mac: ENC[AES256_GCM,data:SZc4vSE4N3lkOpyqn3gLqhPl9E5/zfg+RHK8ZvC8PXxTHYgkVoZUy8o8mHL11wAfhVBlsXpomn/1ASESyzQJ7/dxYNKDUvrywDkiCdnF/OLQi0TElzDKRAhfJHZapCR77TQGGaIFAWZYEsiUiqPGh/f88e9jP8eRqFjAzyEJOME=,iv:wc5WCaQu8UKrml/hn2gCNUnRZeo/38Z8WnZ06S9hJ80=,tag:mexZoBUlgiVJRkugeYfjsA==,type:str]\n" +
-            "    pgp: []\n" +
-            "    unencrypted_suffix: _unencrypted\n" +
-            "    version: 3.9.0"
-    val sopsFileWithShamir2 = "hei: ENC[AES256_GCM,data:8DD8C0g=,iv:WegIEU7t+H4eFaBynjK9WpvoJSdzvmE81OVu5FxC62M=,tag:EEI+4l3Y85PhpwiBsfnEkw==,type:str]\n" +
-            "hva: ENC[AES256_GCM,data:ybxaqB8=,iv:xRxprceL9Fj3QGS0RRTjg63R23xJxfjYsJw1pHuU4PE=,tag:ZPuwrwSK79OSUG/8nAts4A==,type:str]\n" +
-            "sops:\n" +
-            "    shamir_threshold: 2\n" +
-            "    key_groups:\n" +
-            "        - hc_vault: []\n" +
-            "          age:\n" +
-            "            - recipient: age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\n" +
-            "              enc: |\n" +
-            "                -----BEGIN AGE ENCRYPTED FILE-----\n" +
-            "                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1b1dqSmo1YWJSUHVXejhB\n" +
-            "                Wkxwa2ttWlZBV2szYTZDUnh3c2xMWS8rbFhzCm9vRjFHbDJUNjFtTE5WUVZoWVln\n" +
-            "                Wm9wd05UZGlOSzNqRUdxYmdZY0NxNHMKLS0tIHBvZTQ5UFNDR1Q5MUhRMkdmS1hW\n" +
-            "                TG5Gb0RRamtrWUM0L1VjRytXTlRmcE0KV38Q6hW4/6QfTifXG8dbaM3noPDSQtxo\n" +
-            "                t6y58dqsEa9Gm0d+WTbZM2wkEaxxhI8TOM7V9ahwThs6MvYdhkYI3mA=\n" +
-            "                -----END AGE ENCRYPTED FILE-----\n" +
-            "        - gcp_kms:\n" +
-            "            - resource_id: projects/spire-ros-5lmr/locations/eur4/keyRings/ROS/cryptoKeys/ros-as-code\n" +
-            "              created_at: \"2024-08-06T10:44:38Z\"\n" +
-            "              enc: CiQAMVUE/3YwwDvWmZ4OilZLbRcTWHFef1ICqj5SFfG9AOwioVISSgD2ZGIpiNAI+AiE5Ccc+r9IGR/ANzRH9UllvtLL8UaTh+MygyhCoEeYnTr1ievaGz2bjY/oR4sj5lkV6Qt6KRlVX8nJTMQrWBJo\n" +
-            "          hc_vault: []\n" +
-            "          age: []\n" +
-            "    kms: []\n" +
-            "    gcp_kms: []\n" +
-            "    azure_kv: []\n" +
-            "    hc_vault: []\n" +
-            "    age: []\n" +
-            "    lastmodified: \"2024-08-06T10:44:38Z\"\n" +
-            "    mac: ENC[AES256_GCM,data:6KCDbaVisMHW8T/qrAjqG1ir61XGEF996eSTDpsK16VBSEQck6A+/AY5kq9s/UpCKOFKPWqoC6BemCxb6qRAJjpxuq4f5Nzqv9NfS9RFX9qUJPo83UdlDe/eCzUekD4aYjIuLy88qAqv70MuR2GcN0LLCSe8rI8JZNZQ6PXcWlg=,iv:me0zxeGzJPOEWv/fiEzpr82jracN2JjEOVf+AoL61pI=,tag:Ul8XzoMeAjd2yhAjvxRfSw==,type:str]\n" +
-            "    pgp: []\n" +
-            "    unencrypted_suffix: _unencrypted\n" +
-            "    version: 3.9.0"
 
-    // OBS! Remember to remove before committing
-    val validGCPAccessToken = GCPAccessToken("ditt-access-token")
-    val invalidGCPAccessToken = GCPAccessToken("feil")
+    companion object {
+        // OBS! Remember to remove before committing
+        val validGCPAccessToken = GCPAccessToken("ditt gyldige token")
+        val invalidGCPAccessToken = GCPAccessToken("feil")
+
+        val ageKey1 = "AGE-SECRET-KEY-18TRT94XGD8SC06JSJX5Q9PFFA9XRR0SYKNCVGVLL0EJTS93YJFSQ89A8RP"
+        val ageKey2 = "AGE-SECRET-KEY-1FVTKH7URH7YY4MQCPJ3FWYJAJRJAN9U3YQNNHX7HNSNT4QAUEH6QZWSN8Y"
+        val invalidAgeKey = ""
+
+        val clearTextPartOfContent = "hei"
+        val sopsFileWithShamir1 = "hei: ENC[AES256_GCM,data:r5bHVoU=,iv:M3YhjRcP7EFSUP5uyjsvUcUVttcnBmM4GPDgdxmUi2A=,tag:UZLHS679wF6jSWAfftz+iQ==,type:str]\n" +
+                "hva: ENC[AES256_GCM,data:jgxACAo=,iv:fCpggS7M/eFNC1ce0Gmy/7wOgS6sF2igcJwqVqxDy80=,tag:GjWX6R+5GXFewJ50HVTZPQ==,type:str]\n" +
+                "sops:\n" +
+                "    shamir_threshold: 1\n" +
+                "    kms: []\n" +
+                "    gcp_kms:\n" +
+                "        - resource_id: projects/spire-ros-5lmr/locations/europe-west4/keyRings/rosene-team/cryptoKeys/ros-as-code-2\n" +
+                "          created_at: \"2024-08-06T11:07:17Z\"\n" +
+                "          enc: CiQAMvdImh2ugjR7IPggRIHlAmnsgnkrmJJK7/VYS8RGA+SPlpYSSQAWhPfdQsTdmcTh2qD4Rgd5vW6lkdjUV3Hp/jN1ERDzPfQL4YHa0pcqE4WV1WLXHOBb6rlSet2xdyJcJ2FbrNPkynCl3o4+fg8=\n" +
+                "    azure_kv: []\n" +
+                "    hc_vault: []\n" +
+                "    age:\n" +
+                "        - recipient: age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\n" +
+                "          enc: |\n" +
+                "            -----BEGIN AGE ENCRYPTED FILE-----\n" +
+                "            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvNWtXNDJQY2t5cVJUdEp0\n" +
+                "            MXM5Zk1FTitucWo2VUtORk9ZVzNGNk83TERzCk9RMmx1M2RRNGZsd2JKamlHNmlK\n" +
+                "            YjA0UjNIZTZ4Rk1rMExOcVRLM1FIcWsKLS0tIDY2YWN0d28reWdaTGp4NFUyekcy\n" +
+                "            NjJodGNxRlNNbXdlYjM2Q0h3VWlSV1UKfA5PfjTJxu7fcCIvJV5Wd3KirAz+3Jak\n" +
+                "            68mpwGaD5VisPKhe1TPrJdcZ/QjzmOIqotoKpYmrzsIm6jYQxGUypw==\n" +
+                "            -----END AGE ENCRYPTED FILE-----\n" +
+                "    lastmodified: \"2024-08-06T11:07:18Z\"\n" +
+                "    mac: ENC[AES256_GCM,data:SZc4vSE4N3lkOpyqn3gLqhPl9E5/zfg+RHK8ZvC8PXxTHYgkVoZUy8o8mHL11wAfhVBlsXpomn/1ASESyzQJ7/dxYNKDUvrywDkiCdnF/OLQi0TElzDKRAhfJHZapCR77TQGGaIFAWZYEsiUiqPGh/f88e9jP8eRqFjAzyEJOME=,iv:wc5WCaQu8UKrml/hn2gCNUnRZeo/38Z8WnZ06S9hJ80=,tag:mexZoBUlgiVJRkugeYfjsA==,type:str]\n" +
+                "    pgp: []\n" +
+                "    unencrypted_suffix: _unencrypted\n" +
+                "    version: 3.9.0"
+        val sopsFileWithShamir2 = "hei: ENC[AES256_GCM,data:8DD8C0g=,iv:WegIEU7t+H4eFaBynjK9WpvoJSdzvmE81OVu5FxC62M=,tag:EEI+4l3Y85PhpwiBsfnEkw==,type:str]\n" +
+                "hva: ENC[AES256_GCM,data:ybxaqB8=,iv:xRxprceL9Fj3QGS0RRTjg63R23xJxfjYsJw1pHuU4PE=,tag:ZPuwrwSK79OSUG/8nAts4A==,type:str]\n" +
+                "sops:\n" +
+                "    shamir_threshold: 2\n" +
+                "    key_groups:\n" +
+                "        - hc_vault: []\n" +
+                "          age:\n" +
+                "            - recipient: age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\n" +
+                "              enc: |\n" +
+                "                -----BEGIN AGE ENCRYPTED FILE-----\n" +
+                "                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1b1dqSmo1YWJSUHVXejhB\n" +
+                "                Wkxwa2ttWlZBV2szYTZDUnh3c2xMWS8rbFhzCm9vRjFHbDJUNjFtTE5WUVZoWVln\n" +
+                "                Wm9wd05UZGlOSzNqRUdxYmdZY0NxNHMKLS0tIHBvZTQ5UFNDR1Q5MUhRMkdmS1hW\n" +
+                "                TG5Gb0RRamtrWUM0L1VjRytXTlRmcE0KV38Q6hW4/6QfTifXG8dbaM3noPDSQtxo\n" +
+                "                t6y58dqsEa9Gm0d+WTbZM2wkEaxxhI8TOM7V9ahwThs6MvYdhkYI3mA=\n" +
+                "                -----END AGE ENCRYPTED FILE-----\n" +
+                "        - gcp_kms:\n" +
+                "            - resource_id: projects/spire-ros-5lmr/locations/eur4/keyRings/ROS/cryptoKeys/ros-as-code\n" +
+                "              created_at: \"2024-08-06T10:44:38Z\"\n" +
+                "              enc: CiQAMVUE/3YwwDvWmZ4OilZLbRcTWHFef1ICqj5SFfG9AOwioVISSgD2ZGIpiNAI+AiE5Ccc+r9IGR/ANzRH9UllvtLL8UaTh+MygyhCoEeYnTr1ievaGz2bjY/oR4sj5lkV6Qt6KRlVX8nJTMQrWBJo\n" +
+                "          hc_vault: []\n" +
+                "          age: []\n" +
+                "    kms: []\n" +
+                "    gcp_kms: []\n" +
+                "    azure_kv: []\n" +
+                "    hc_vault: []\n" +
+                "    age: []\n" +
+                "    lastmodified: \"2024-08-06T10:44:38Z\"\n" +
+                "    mac: ENC[AES256_GCM,data:6KCDbaVisMHW8T/qrAjqG1ir61XGEF996eSTDpsK16VBSEQck6A+/AY5kq9s/UpCKOFKPWqoC6BemCxb6qRAJjpxuq4f5Nzqv9NfS9RFX9qUJPo83UdlDe/eCzUekD4aYjIuLy88qAqv70MuR2GcN0LLCSe8rI8JZNZQ6PXcWlg=,iv:me0zxeGzJPOEWv/fiEzpr82jracN2JjEOVf+AoL61pI=,tag:Ul8XzoMeAjd2yhAjvxRfSw==,type:str]\n" +
+                "    pgp: []\n" +
+                "    unencrypted_suffix: _unencrypted\n" +
+                "    version: 3.9.0"
+
+        val sopsFileWithDifferentGCPResourceAndAgeKey = ""
+
+
+        class DecryptionParameters(
+            val gcpAccessToken: GCPAccessToken,
+            val ageKey: String,
+            val cipherText: String
+        )
+
+        val cipherTextWithAge1 =  "hei: ENC[AES256_GCM,data:LwQHXY0=,iv:KZ1W3FxTubvbmeQl6fjHfvIh7J7T2bEGD5PaF8INGBM=,tag:3HcsDICtwqGIg3dfMJifuA==,type:str]\n" +
+                "hva: ENC[AES256_GCM,data:e6++Q+U=,iv:0noiujc8o+mTrQw0CNWUHcQs7G1yjBdnIYt3aoBhuus=,tag:LjeBxw1ZBSowRqNhRC922Q==,type:str]\n" +
+                "sops:\n" +
+                "    shamir_threshold: 2\n" +
+                "    key_groups:\n" +
+                "        - hc_vault: []\n" +
+                "          age:\n" +
+                "            - recipient: age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\n" +
+                "              enc: |\n" +
+                "                -----BEGIN AGE ENCRYPTED FILE-----\n" +
+                "                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZ2RsK1Z6eWRQUmhINlNn\n" +
+                "                cTRWTWMyMjdrZStzaGNjQVJrdWJVcWo4QUFFCjlqVkhDTUJKeVFIb0svSy9tS0tn\n" +
+                "                ajd4dTBMUXorb3J1WkE1NnpxNkFQamMKLS0tIENuYUNSWGxOTnNLY2MzL2hJUGlt\n" +
+                "                amJGUERraElZUCtXYTRCengzYXpOK2MKxiDIzA8jytgsJn0cvkX4i1jKmpxqEmzx\n" +
+                "                LZUFQ8GIOUFu3dfueS0JAaxLMywQ9jGTiPwM/MGIycxG8o4bx1MeIts=\n" +
+                "                -----END AGE ENCRYPTED FILE-----\n" +
+                "        - gcp_kms:\n" +
+                "            - resource_id: projects/spire-ros-5lmr/locations/europe-west4/keyRings/rosene-team/cryptoKeys/ros-as-code-2\n" +
+                "              created_at: \"2024-08-07T10:02:21Z\"\n" +
+                "              enc: CiQAMvdImiH53mjZbagHznhyPOZBDZfoXtvG1x+km3eF9gbxhuwSSgAWhPfdyibcwoAsb/vfqs9sMJ6Z93UDRoArEPHDCuW76pHO6MTb2sfgJGDddv2SE12Rie/J13drgFHJO3PaBRAs4rIh0OCJhbLj\n" +
+                "          hc_vault: []\n" +
+                "          age: []\n" +
+                "    kms: []\n" +
+                "    gcp_kms: []\n" +
+                "    azure_kv: []\n" +
+                "    hc_vault: []\n" +
+                "    age: []\n" +
+                "    lastmodified: \"2024-08-07T10:02:21Z\"\n" +
+                "    mac: ENC[AES256_GCM,data:l0SqUJ3ZWXmaY8gA2rTdoUq/RKBw4O52KRIdWRd0EAXI3Xf1ZyXYHBKa1UF82geZXKPFqKAMtVRyxRpwtuBRAEsd96pGIJI31ko0HRJrhSEg9CZqI1pfW0gbN+1qH++kaFoV8+otJ3eZfCTy1h4jm3EOYNrR5gJlNMGm+4ib4nw=,iv:mhD1UCWSOe9iOEoBMeCs9EqfY2yxp021D9MKuGaP6RE=,tag:kjRBm9eYIZ1n9d39D9edDQ==,type:str]\n" +
+                "    pgp: []\n" +
+                "    unencrypted_suffix: _unencrypted\n" +
+                "    version: 3.9.0"
+        val cipherTextWithAge2 = "hei: ENC[AES256_GCM,data:mO8KEj0=,iv:HBAq6EcL9xz4ByW+BtSxoozvHFaKLQ+Rc1+I4/JeWQQ=,tag:ipyXK343QfcuzEcdcEc13g==,type:str]\n" +
+                "hva: ENC[AES256_GCM,data:D16Q6/M=,iv:8Do4gzPCHCs/RhvGlan2IQGcs9NQsWu9GsFjUylqtvU=,tag:lddQe0BQwI1DZ0uurNVuUg==,type:str]\n" +
+                "sops:\n" +
+                "    shamir_threshold: 2\n" +
+                "    key_groups:\n" +
+                "        - hc_vault: []\n" +
+                "          age:\n" +
+                "            - recipient: age1u2j2lqd97qwfaynnx324jf9g8lfhvucslwa286yfwva4wjrw75zq5u9qfr\n" +
+                "              enc: |\n" +
+                "                -----BEGIN AGE ENCRYPTED FILE-----\n" +
+                "                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPSnluV0NxMmFOQ0dZb3M2\n" +
+                "                N2M2QVJjMmc2WTlRRHk0SDJkVy9IZWphN3dRCmtFZ2svak43WWlubzk0K25hODhS\n" +
+                "                YkZ2ZVkzMEhIeU0zdktYR3ZTTHRsY00KLS0tIE1kODFVVlE3ZkZJUS8rOU1GSFhI\n" +
+                "                VmRVZmhzYWF3Z1VLUXhoYy9HTityQzgKa1Nvogc0SBgmlejyV3g2wLQ4EuCwokvk\n" +
+                "                ciGw1YFhvKq2KUVtVGwMmCUYutNddDXSehP1TmplWO6Dq+H0WJc4bxA=\n" +
+                "                -----END AGE ENCRYPTED FILE-----\n" +
+                "        - gcp_kms:\n" +
+                "            - resource_id: projects/spire-ros-5lmr/locations/global/keyRings/sops-test/cryptoKeys/sopskey1\n" +
+                "              created_at: \"2024-08-07T10:02:28Z\"\n" +
+                "              enc: CiQAE5QSj2zUooNY7a+AHFJ1DC5CggddKEXxS5Ee8Von5Kv1aqsSSgDjvMzLDrYCuj0jtAOnGxYYpLj5gPtmHtKGJPwHkZ+gI7dIbCQ08UF+8BuH4rMXqYdqAvAa9ui2AJp2czxv/cKjFjA3e1hzd0TD\n" +
+                "          hc_vault: []\n" +
+                "          age: []\n" +
+                "    kms: []\n" +
+                "    gcp_kms: []\n" +
+                "    azure_kv: []\n" +
+                "    hc_vault: []\n" +
+                "    age: []\n" +
+                "    lastmodified: \"2024-08-07T10:02:28Z\"\n" +
+                "    mac: ENC[AES256_GCM,data:qk0PScNnb0kY3QBHtJl6MPsFydDBGXAdLGsRTNtZ+DJNwwszCSG2RuhP5hi5yhgoY36jlx8g2zJQ/SnEU4VtiLKD03H50mzXzCRNad0ErxG4UDlxJXZwGJTNXORM0CEHj8MEaadrx6iUa8aowCVzgSkpxaBt4S1zrFcZ964tAvY=,iv:t1YwioO7CH5x2POpCaRLIgdle5PhZaUGnP4Mwl/Xp8g=,tag:FUj8KzcNDvEOBLuwit16zw==,type:str]\n" +
+                "    pgp: []\n" +
+                "    unencrypted_suffix: _unencrypted\n" +
+                "    version: 3.9.0"
+
+        val arbitraryDecryptionParameters1 =  DecryptionParameters(
+            gcpAccessToken = validGCPAccessToken,
+            ageKey = ageKey1,
+            cipherText = cipherTextWithAge1
+        )
+
+        val arbitraryDecryptionParameters2 =  DecryptionParameters(
+            gcpAccessToken = validGCPAccessToken,
+            ageKey = ageKey2,
+            cipherText = cipherTextWithAge2
+        )
+
+        @JvmStatic
+        fun listOfDecryptionParameters(): Stream<Arguments> = Stream.of(
+            Arguments.of(arbitraryDecryptionParameters1),
+            Arguments.of(arbitraryDecryptionParameters2),
+            Arguments.of(arbitraryDecryptionParameters1),
+            Arguments.of(arbitraryDecryptionParameters1),
+            Arguments.of(arbitraryDecryptionParameters2),
+            Arguments.of(arbitraryDecryptionParameters2),
+            Arguments.of(arbitraryDecryptionParameters1),
+            Arguments.of(arbitraryDecryptionParameters1),
+            Arguments.of(arbitraryDecryptionParameters2),
+            Arguments.of(arbitraryDecryptionParameters2),
+            Arguments.of(arbitraryDecryptionParameters1),
+            Arguments.of(arbitraryDecryptionParameters1),
+            Arguments.of(arbitraryDecryptionParameters1),
+            Arguments.of(arbitraryDecryptionParameters2),
+            Arguments.of(arbitraryDecryptionParameters2),
+            Arguments.of(arbitraryDecryptionParameters2),
+        )
+
+        val decryptionService = DecryptionService()
+    }
+
 
     @Test
     fun `when age key is present and shamir is 1 the ciphertext is successfully decrypted`(){
-        DecryptionService().decrypt(sopsFileWithShamir1, invalidGCPAccessToken, ageKey)
+        decryptionService.decrypt(sopsFileWithShamir1, invalidGCPAccessToken, ageKey1)
     }
 
     @Test
     fun `when gcp access token is valid and shamir is 1 the ciphertext is successfully decrypted`(){
-        DecryptionService().decrypt(sopsFileWithShamir1, validGCPAccessToken, invalidAgeKey)
+        decryptionService.decrypt(sopsFileWithShamir1, validGCPAccessToken, invalidAgeKey)
     }
 
     @Test
     fun `when age key and gcp access token is present and shamir is 2 the ciphertext is successfully decrypted`(){
-        DecryptionService().decrypt(sopsFileWithShamir2, validGCPAccessToken, ageKey)
+        decryptionService.decrypt(sopsFileWithShamir2, validGCPAccessToken, ageKey1)
     }
 
     @Test
     fun `when age key is not present and gcp access token is valid and shamir is 2 the decryption fails`(){
-        assertThrows<Exception> { DecryptionService().decrypt(sopsFileWithShamir2, validGCPAccessToken, invalidAgeKey) }
+        assertThrows<Exception> { decryptionService.decrypt(sopsFileWithShamir2, validGCPAccessToken, invalidAgeKey) }
     }
 
     @Test
     fun `when age and key is present but gcp access token is invalid and shamir is 2 the decryption fails`(){
-        assertThrows<Exception> { DecryptionService().decrypt(sopsFileWithShamir2, invalidGCPAccessToken, ageKey) }
+        assertThrows<Exception> { decryptionService.decrypt(sopsFileWithShamir2, invalidGCPAccessToken, ageKey1) }
+    }
+
+    @Execution(ExecutionMode.CONCURRENT)
+    @ParameterizedTest
+    @MethodSource("listOfDecryptionParameters")
+    fun `test that decryption works with concurrency`(decryptionParameters: DecryptionParameters) {
+        val result = decryptionService.decrypt(
+            ciphertext = decryptionParameters.cipherText,
+            gcpAccessToken = decryptionParameters.gcpAccessToken,
+            sopsAgeKey = decryptionParameters.ageKey
+        )
+
+        assertThat(result).contains(clearTextPartOfContent)
     }
 }

--- a/src/test/kotlin/cryptoservice/service/DecryptionServiceTest.kt
+++ b/src/test/kotlin/cryptoservice/service/DecryptionServiceTest.kt
@@ -1,0 +1,99 @@
+package cryptoservice.service
+
+import cryptoservice.model.GCPAccessToken
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@Disabled
+class DecryptionServiceTest {
+    val ageKey = "AGE-SECRET-KEY-18TRT94XGD8SC06JSJX5Q9PFFA9XRR0SYKNCVGVLL0EJTS93YJFSQ89A8RP"
+    val invalidAgeKey = ""
+    val sopsFileWithShamir1 = "hei: ENC[AES256_GCM,data:r5bHVoU=,iv:M3YhjRcP7EFSUP5uyjsvUcUVttcnBmM4GPDgdxmUi2A=,tag:UZLHS679wF6jSWAfftz+iQ==,type:str]\n" +
+            "hva: ENC[AES256_GCM,data:jgxACAo=,iv:fCpggS7M/eFNC1ce0Gmy/7wOgS6sF2igcJwqVqxDy80=,tag:GjWX6R+5GXFewJ50HVTZPQ==,type:str]\n" +
+            "sops:\n" +
+            "    shamir_threshold: 1\n" +
+            "    kms: []\n" +
+            "    gcp_kms:\n" +
+            "        - resource_id: projects/spire-ros-5lmr/locations/europe-west4/keyRings/rosene-team/cryptoKeys/ros-as-code-2\n" +
+            "          created_at: \"2024-08-06T11:07:17Z\"\n" +
+            "          enc: CiQAMvdImh2ugjR7IPggRIHlAmnsgnkrmJJK7/VYS8RGA+SPlpYSSQAWhPfdQsTdmcTh2qD4Rgd5vW6lkdjUV3Hp/jN1ERDzPfQL4YHa0pcqE4WV1WLXHOBb6rlSet2xdyJcJ2FbrNPkynCl3o4+fg8=\n" +
+            "    azure_kv: []\n" +
+            "    hc_vault: []\n" +
+            "    age:\n" +
+            "        - recipient: age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\n" +
+            "          enc: |\n" +
+            "            -----BEGIN AGE ENCRYPTED FILE-----\n" +
+            "            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvNWtXNDJQY2t5cVJUdEp0\n" +
+            "            MXM5Zk1FTitucWo2VUtORk9ZVzNGNk83TERzCk9RMmx1M2RRNGZsd2JKamlHNmlK\n" +
+            "            YjA0UjNIZTZ4Rk1rMExOcVRLM1FIcWsKLS0tIDY2YWN0d28reWdaTGp4NFUyekcy\n" +
+            "            NjJodGNxRlNNbXdlYjM2Q0h3VWlSV1UKfA5PfjTJxu7fcCIvJV5Wd3KirAz+3Jak\n" +
+            "            68mpwGaD5VisPKhe1TPrJdcZ/QjzmOIqotoKpYmrzsIm6jYQxGUypw==\n" +
+            "            -----END AGE ENCRYPTED FILE-----\n" +
+            "    lastmodified: \"2024-08-06T11:07:18Z\"\n" +
+            "    mac: ENC[AES256_GCM,data:SZc4vSE4N3lkOpyqn3gLqhPl9E5/zfg+RHK8ZvC8PXxTHYgkVoZUy8o8mHL11wAfhVBlsXpomn/1ASESyzQJ7/dxYNKDUvrywDkiCdnF/OLQi0TElzDKRAhfJHZapCR77TQGGaIFAWZYEsiUiqPGh/f88e9jP8eRqFjAzyEJOME=,iv:wc5WCaQu8UKrml/hn2gCNUnRZeo/38Z8WnZ06S9hJ80=,tag:mexZoBUlgiVJRkugeYfjsA==,type:str]\n" +
+            "    pgp: []\n" +
+            "    unencrypted_suffix: _unencrypted\n" +
+            "    version: 3.9.0"
+    val sopsFileWithShamir2 = "hei: ENC[AES256_GCM,data:8DD8C0g=,iv:WegIEU7t+H4eFaBynjK9WpvoJSdzvmE81OVu5FxC62M=,tag:EEI+4l3Y85PhpwiBsfnEkw==,type:str]\n" +
+            "hva: ENC[AES256_GCM,data:ybxaqB8=,iv:xRxprceL9Fj3QGS0RRTjg63R23xJxfjYsJw1pHuU4PE=,tag:ZPuwrwSK79OSUG/8nAts4A==,type:str]\n" +
+            "sops:\n" +
+            "    shamir_threshold: 2\n" +
+            "    key_groups:\n" +
+            "        - hc_vault: []\n" +
+            "          age:\n" +
+            "            - recipient: age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\n" +
+            "              enc: |\n" +
+            "                -----BEGIN AGE ENCRYPTED FILE-----\n" +
+            "                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1b1dqSmo1YWJSUHVXejhB\n" +
+            "                Wkxwa2ttWlZBV2szYTZDUnh3c2xMWS8rbFhzCm9vRjFHbDJUNjFtTE5WUVZoWVln\n" +
+            "                Wm9wd05UZGlOSzNqRUdxYmdZY0NxNHMKLS0tIHBvZTQ5UFNDR1Q5MUhRMkdmS1hW\n" +
+            "                TG5Gb0RRamtrWUM0L1VjRytXTlRmcE0KV38Q6hW4/6QfTifXG8dbaM3noPDSQtxo\n" +
+            "                t6y58dqsEa9Gm0d+WTbZM2wkEaxxhI8TOM7V9ahwThs6MvYdhkYI3mA=\n" +
+            "                -----END AGE ENCRYPTED FILE-----\n" +
+            "        - gcp_kms:\n" +
+            "            - resource_id: projects/spire-ros-5lmr/locations/eur4/keyRings/ROS/cryptoKeys/ros-as-code\n" +
+            "              created_at: \"2024-08-06T10:44:38Z\"\n" +
+            "              enc: CiQAMVUE/3YwwDvWmZ4OilZLbRcTWHFef1ICqj5SFfG9AOwioVISSgD2ZGIpiNAI+AiE5Ccc+r9IGR/ANzRH9UllvtLL8UaTh+MygyhCoEeYnTr1ievaGz2bjY/oR4sj5lkV6Qt6KRlVX8nJTMQrWBJo\n" +
+            "          hc_vault: []\n" +
+            "          age: []\n" +
+            "    kms: []\n" +
+            "    gcp_kms: []\n" +
+            "    azure_kv: []\n" +
+            "    hc_vault: []\n" +
+            "    age: []\n" +
+            "    lastmodified: \"2024-08-06T10:44:38Z\"\n" +
+            "    mac: ENC[AES256_GCM,data:6KCDbaVisMHW8T/qrAjqG1ir61XGEF996eSTDpsK16VBSEQck6A+/AY5kq9s/UpCKOFKPWqoC6BemCxb6qRAJjpxuq4f5Nzqv9NfS9RFX9qUJPo83UdlDe/eCzUekD4aYjIuLy88qAqv70MuR2GcN0LLCSe8rI8JZNZQ6PXcWlg=,iv:me0zxeGzJPOEWv/fiEzpr82jracN2JjEOVf+AoL61pI=,tag:Ul8XzoMeAjd2yhAjvxRfSw==,type:str]\n" +
+            "    pgp: []\n" +
+            "    unencrypted_suffix: _unencrypted\n" +
+            "    version: 3.9.0"
+
+    // OBS! Remember to remove before committing
+    val validGCPAccessToken = GCPAccessToken("ditt-access-token")
+    val invalidGCPAccessToken = GCPAccessToken("feil")
+
+    @Test
+    fun `when age key is present and shamir is 1 the ciphertext is successfully decrypted`(){
+        DecryptionService().decrypt(sopsFileWithShamir1, invalidGCPAccessToken, ageKey)
+    }
+
+    @Test
+    fun `when gcp access token is valid and shamir is 1 the ciphertext is successfully decrypted`(){
+        DecryptionService().decrypt(sopsFileWithShamir1, validGCPAccessToken, invalidAgeKey)
+    }
+
+    @Test
+    fun `when age key and gcp access token is present and shamir is 2 the ciphertext is successfully decrypted`(){
+        DecryptionService().decrypt(sopsFileWithShamir2, validGCPAccessToken, ageKey)
+    }
+
+    @Test
+    fun `when age key is not present and gcp access token is valid and shamir is 2 the decryption fails`(){
+        assertThrows<Exception> { DecryptionService().decrypt(sopsFileWithShamir2, validGCPAccessToken, invalidAgeKey) }
+    }
+
+    @Test
+    fun `when age and key is present but gcp access token is invalid and shamir is 2 the decryption fails`(){
+        assertThrows<Exception> { DecryptionService().decrypt(sopsFileWithShamir2, invalidGCPAccessToken, ageKey) }
+    }
+}

--- a/src/test/kotlin/cryptoservice/service/EncryptionServiceTest.kt
+++ b/src/test/kotlin/cryptoservice/service/EncryptionServiceTest.kt
@@ -1,24 +1,50 @@
 package cryptoservice.service
 
 import cryptoservice.model.GCPAccessToken
-import cryptoservice.service.EncryptionService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class EncryptionServiceTest {
+    @Disabled
     @Test
-    fun `encrypt data`() {
+    fun `when gcp access token is available data is successfully encrypted`() {
+        val gcpAccessToken = GCPAccessToken("din-access-token")
+        val configWithGCPResourceAndAge = "creation_rules:\n" +
+                "    - key_groups:\n" +
+                "        - age:\n" +
+                "            - \"age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\"\n"+
+                "        - gcp_kms:\n" +
+                "            - resource_id: projects/spire-ros-5lmr/locations/europe-west4/keyRings/rosene-team/cryptoKeys/ros-as-code-2"
+
         val encrypted = EncryptionService().encrypt(
             text = "{\"test\":\"test\"}",
-            config = "creation_rules:\n" +
-                    "    - key_groups:\n" +
-                    "        - age:\n" +
-                    "            - \"age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\"\n"+
-                    "        - gcp_kms:\n" +
-                    "            - resource_id: projects/spire-ros-5lmr/locations/europe-west4/keyRings/rosene-team/cryptoKeys/ros-as-code-2",
-            gcpAccessToken = GCPAccessToken("xxx-din-gcp-token"),
+            config = configWithGCPResourceAndAge,
+            gcpAccessToken = gcpAccessToken,
             riScId = "ad-12314"
         )
 
-        println(encrypted)
+        assertThat(encrypted).isNotNull()
+        assertThat(encrypted).contains("sops")
     }
+
+    @Test
+    fun `when `() {
+        val invalidGcpAccessToken = GCPAccessToken("feil")
+        val configWithGCPResourceAndAge = "creation_rules:\n" +
+                "    - key_groups:\n" +
+                "        - age:\n" +
+                "            - \"age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\"\n"+
+                "        - gcp_kms:\n" +
+                "            - resource_id: projects/spire-ros-5lmr/locations/europe-west4/keyRings/rosene-team/cryptoKeys/ros-as-code-2"
+
+        assertThrows<Exception> { EncryptionService().encrypt(
+            text = "{\"test\":\"test\"}",
+            config = configWithGCPResourceAndAge,
+            gcpAccessToken = invalidGcpAccessToken,
+            riScId = "ad-12314"
+        ) }
+    }
+
 }

--- a/src/test/kotlin/cryptoservice/service/EncryptionServiceTest.kt
+++ b/src/test/kotlin/cryptoservice/service/EncryptionServiceTest.kt
@@ -30,7 +30,7 @@ class EncryptionServiceTest {
     }
 
     @Test
-    fun `when `() {
+    fun `when gcp access token is invalid an exception is thrown`() {
         val invalidGcpAccessToken = GCPAccessToken("feil")
         val configWithGCPResourceAndAge = "creation_rules:\n" +
                 "    - key_groups:\n" +

--- a/src/test/kotlin/cryptoservice/service/EncryptionServiceTest.kt
+++ b/src/test/kotlin/cryptoservice/service/EncryptionServiceTest.kt
@@ -1,0 +1,24 @@
+package cryptoservice.service
+
+import cryptoservice.model.GCPAccessToken
+import cryptoservice.service.EncryptionService
+import org.junit.jupiter.api.Test
+
+class EncryptionServiceTest {
+    @Test
+    fun `encrypt data`() {
+        val encrypted = EncryptionService().encrypt(
+            text = "{\"test\":\"test\"}",
+            config = "creation_rules:\n" +
+                    "    - key_groups:\n" +
+                    "        - age:\n" +
+                    "            - \"age1g9m644t5s95zk6px9mh2kctajqw3guuq2alntgfqu2au6fdz85lq4uupug\"\n"+
+                    "        - gcp_kms:\n" +
+                    "            - resource_id: projects/spire-ros-5lmr/locations/europe-west4/keyRings/rosene-team/cryptoKeys/ros-as-code-2",
+            gcpAccessToken = GCPAccessToken("xxx-din-gcp-token"),
+            riScId = "ad-12314"
+        )
+
+        println(encrypted)
+    }
+}


### PR DESCRIPTION
## Endre litt på kommandoen vi sender inn for å gjøre kryptering og dekryptering 🍄🍄
### 🔒 Encrypt 
- Bruker ```sops --encrypt``` istedenfor ```sops encrypt``` for å kunne ha muligheten til å sende med en config-fil.
- Config-fila(.sops.yaml) er nå lagret som en temp-fil som slettes etter bruk.
- Sender med access token for gcp-kms

### 🔓 Decrypt
- Sender med age-key og access token som environment variabler for den gitte kommandoen


Endret også litt på hvordan vi bygget kommandoen sånn at det er enklere å lese hva den faktisk skal gjøre (? 😊)