### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Eiendom
+version: 3.0
+organization: Eiendom
+product: 
+repo_types: [Service]
+platforms: [SKIP]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,1 +1,38 @@
-Audiences in Jwt are not allowed
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "backstage-plugin-risk-crypto-service"
+  tags:
+  - "internal"
+spec:
+  type: "service"
+  lifecycle: "production"
+  owner: "skvis"
+  system: "ros-as-code"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_backstage-plugin-risk-crypto-service"
+  title: "Security Champion backstage-plugin-risk-crypto-service"
+spec:
+  type: "security_champion"
+  parent: "eiendom_security_champions"
+  members:
+  - "larsore"
+  children:
+  - "resource:backstage-plugin-risk-crypto-service"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "backstage-plugin-risk-crypto-service"
+  links:
+  - url: "https://github.com/kartverket/backstage-plugin-risk-crypto-service"
+    title: "backstage-plugin-risk-crypto-service på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_backstage-plugin-risk-crypto-service"
+  dependencyOf:
+  - "component:backstage-plugin-risk-crypto-service"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,1 @@
+Audiences in Jwt are not allowed


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Eiendom`
- `product: `
- `repo_types: [Service]`
- `platforms: [SKIP]`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.