### PR TITLE
[Sikkerhet] Oppretter initiell risiko- og sårbarhetsanalyse (RoS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @larsore
+/.security/ @larsore

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Eiendom
 product: 
 repo_types: [Service]

--- a/.security/risc/.sops.yaml
+++ b/.security/risc/.sops.yaml
@@ -1,0 +1,12 @@
+creation_rules:
+- path_regex: \.risc\.yaml$
+  shamir_threshold: 2
+  key_groups:
+  - age:
+    - age145s860ux96jvx6d7nwvzar588qjmgv5p47sp6nmmt2jnmhqh4scqcuk0mg
+    gcp_kms:
+    - resource_id: 
+        projects/skvis-prod-9329/locations/europe-north1/keyRings/skvis-risc-key-ring/cryptoKeys/skvis-risc-crypto-key
+  - age:
+    - age18e0t6ve0vdxqzzjt7rxf0r6vzc37fhs5cad2qz40r02c3spzgvvq8uxz23
+    - age1kjpgclkjev08aa8l2uy277gn0cngrkrkazt240405ezqywkm5axqt3d3tq

--- a/.security/risc/risc-default.risc.yaml
+++ b/.security/risc/risc-default.risc.yaml
@@ -1,0 +1,48 @@
+sops:
+    shamir_threshold: 2
+    key_groups:
+        - gcp_kms:
+            - resource_id: projects/skvis-prod-9329/locations/europe-north1/keyRings/skvis-risc-key-ring/cryptoKeys/skvis-risc-crypto-key
+              created_at: "2025-02-19T12:54:03Z"
+              enc: CiQAikFTnBlxPk1DEz0AhmAdGMhTFCC77q/SiN2RiixRJSzz/AUSSgBdjvfeIMou0PF9fGdCb1qgg5g15QtNL5z5+Sa3t8tAOG4GFAPCGq7nZaMDGG+he06V49+VsTPs/YiLIzTsKNsd6zOsgavgXGHX
+          hc_vault: []
+          age:
+            - recipient: age145s860ux96jvx6d7nwvzar588qjmgv5p47sp6nmmt2jnmhqh4scqcuk0mg
+              enc: |
+                -----BEGIN AGE ENCRYPTED FILE-----
+                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNdlJwRlB0SnF5NC9pa2RE
+                SEV3WnRRMmNldHgvYlhjOXBwMVlrdm5VM3pnClZ0RmhlL1RoWUpXRXNPSTFtM2N5
+                NUZQOXY2MlluZVlYcFcxRUQzelh5OGcKLS0tIEgwWWQycE1GZFlCNWRnaVNqVy80
+                b1Vyb3d4akdXRUNaNFp5aEtyNHI5RTAK5RmMnXZiNYpoLiyTPgDkWPdpTXOXxjtf
+                i51VgSj91Ro84m7SBLy22mR0tU1cpESQ6zC0kI4COds2bU3OT8CBeKw=
+                -----END AGE ENCRYPTED FILE-----
+        - hc_vault: []
+          age:
+            - recipient: age18e0t6ve0vdxqzzjt7rxf0r6vzc37fhs5cad2qz40r02c3spzgvvq8uxz23
+              enc: |
+                -----BEGIN AGE ENCRYPTED FILE-----
+                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTTDdZZ1l4aDh0amt5a0hR
+                SGNHRUdLVzM2UlJlTmN5N3hRYnVzRVFUT1djCkFTdklNMVR5S0E4ZjBBWUQ0NWFP
+                NDcrUU5kT3ZTV0pnU0F3WURwaWpqRGMKLS0tIHdNNkgrbUFTVHpydDloZTdMU1ls
+                L0JRM21HRmhvRVUycTAyc1IyQ3dqSjgKgDnHITMd2MqBl99f6CB54CZ3Iq6vqGkq
+                TEXXjcV0W+wTpHvvBE6vJK97yFs515bIgkxPxy2XKWA8wW+sl+pewJ0=
+                -----END AGE ENCRYPTED FILE-----
+            - recipient: age1kjpgclkjev08aa8l2uy277gn0cngrkrkazt240405ezqywkm5axqt3d3tq
+              enc: |
+                -----BEGIN AGE ENCRYPTED FILE-----
+                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHaXp1alRjS3RYcncwYXpz
+                L2RWVG1FODRpMkVyNStPdnk5UWFPTnFLUW5rCmVZNmgwU3p5Tm9xcFpzcnpnSUJL
+                eUpLeDNXMGErdm1lNkJaenVLZ0Z4c28KLS0tIFBhaFVxV2tqZTJpZ0NlVW56NHhN
+                c09VUzFUeEZJNi92dENpbnZsUkdMS1kKMjwX6herfaDmuUypMX6iUCeG2H1JncWY
+                YHDmd5GFnBe6XAJwVVDDku4cg3KivtGUWE1mrBlZNBkbhXPbnH/dk6E=
+                -----END AGE ENCRYPTED FILE-----
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2025-02-19T12:54:09Z"
+    mac: ENC[AES256_GCM,data:mnO/fdhNQ/EDyAK3XIYKt7zTAAnRwxSlP070mNjwjSJDU8Di4re04ddl9w03CC9Uul8w8E4weg5W1ZMHJ1qFjT0XA8gCFk/rsFjLmxm+v38y4shEymP0ekGloPGCruKIxjgKERbidsbQXv+843dnln67baLl9+0qN0dUVHG0ciE=,iv:uxSVye8N22otagBI4dFVrqbzOoZcoWrOFDxDnOfnFFA=,tag:F/bFkJ1opSsDvvsINtPrzA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.0

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "skvis"
   system: "ros-as-code"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_backstage-plugin-risk-crypto-service"
-  title: "Security Champion backstage-plugin-risk-crypto-service"
-spec:
-  type: "security_champion"
-  parent: "eiendom_security_champions"
-  members:
-  - "larsore"
-  children:
-  - "resource:backstage-plugin-risk-crypto-service"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "backstage-plugin-risk-crypto-service"
-  links:
-  - url: "https://github.com/kartverket/backstage-plugin-risk-crypto-service"
-    title: "backstage-plugin-risk-crypto-service på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_backstage-plugin-risk-crypto-service"
-  dependencyOf:
-  - "component:backstage-plugin-risk-crypto-service"


### PR DESCRIPTION
## Kort forklart
Denne PRen oppretter filene `.security/risc/.sops.yaml` og `.security\risc\risc-default.risc.yaml`.
I tillegg omdøpes `.sikkerhet/beskrivelse.yaml` til `.security/description.yaml`, og `CODEOWNERS` endres til at Security Champion får eierskap til `.security`. `.sikkerhet`-mappa skal dermed være tom, og derfor slettes den.
`catalog-info.yaml` oppdateres eventuelt til siste versjon, eller opprettes hvis den ikke finnes fra før.

- `.sops.yaml` inneholder nøklene som RiSc-filer skal krypteres med.
- `risc-default.risc.yaml` er den (krypterte) initielle risiko- og sårbarhetsanalysen (RoSen) for repoet basert på [sikkerhetsmetrikkene](https://kartverket.dev/catalog/default/component/backstage-plugin-risk-crypto-service/securityMetrics) og vanlige sikkerhetskontrollere.

RoSen kan leses og redigeres i [utviklerportalen](https://kartverket.dev/catalog/default/component/backstage-plugin-risk-crypto-service/risc/risc-default).
Det står mer om den initielle RoSen [her](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/1308065798/Initiell+RoS).

## Litt lenger forklart (hvorfor gjør vi dette?)
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet#Versjon-4.0%3A-Koden%C3%A6r-risiko--og-s%C3%A5rbarhetsanalyse-(RoS)).