### PR TITLE
[Sikkerhet] Oppretter initiell risiko- og sårbarhetsanalyse (RoS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @larsore
+/.security/ @larsore

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Eiendom
 product: 
 repo_types: [Service]

--- a/.security/risc/.sops.yaml
+++ b/.security/risc/.sops.yaml
@@ -1,0 +1,12 @@
+creation_rules:
+- path_regex: \.risc\.yaml$
+  shamir_threshold: 2
+  key_groups:
+  - age:
+    - age145s860ux96jvx6d7nwvzar588qjmgv5p47sp6nmmt2jnmhqh4scqcuk0mg
+    gcp_kms:
+    - resource_id: 
+        projects/skvis-prod-9329/locations/europe-north1/keyRings/skvis-risc-key-ring/cryptoKeys/skvis-risc-crypto-key
+  - age:
+    - age18e0t6ve0vdxqzzjt7rxf0r6vzc37fhs5cad2qz40r02c3spzgvvq8uxz23
+    - age1kjpgclkjev08aa8l2uy277gn0cngrkrkazt240405ezqywkm5axqt3d3tq

--- a/.security/risc/risc-default.risc.yaml
+++ b/.security/risc/risc-default.risc.yaml
@@ -1,0 +1,1036 @@
+schemaVersion: ENC[AES256_GCM,data:3u+B,iv:KZic4Co6l+XQ923uWgu3V/v1AUOYf4p8f2UlZlWxt2c=,tag:fj9SlaVhTzYc1/lr/T8Z6A==,type:str]
+title: ENC[AES256_GCM,data:EUP0CYvPxswRn/1rXDQBOLBLj94Cxw==,iv:a/BE1u91VF3ruhrxqJOe4+8yQidqFqFse/LiiY1420c=,tag:AVG/PZEoANSREuv8olXSDw==,type:str]
+scope: ENC[AES256_GCM,data:hRyQwCf4jZA5GRD78noR66tshtMRKomag/yxuMuuZm7AZSJMExLNKl0r2vmf2J+HEw7TCuVQsBqvo3YpSXnX1UWuHAP9YQIZh7HBG9j7dWeRt5o7TVcwOv5sTjLloeNUvL+PaWR2y3qQtALz69XG521+4k1DVv76Q15xHYkTCkCy6g0wFE1TWn4i8FjEwPP80wSYIZfdLOPDSFodwLFxPurBgT6bW0tV/v35e6tKrhej0e8pqZECtFnxfqRjrC7HVPVjIK1Fahd/NFz8xn0cVg==,iv:a8K7D3/m15WSQHQUv2zTAXg7H0eCFh/8H9+nBzb1d9g=,tag:ShU8GRuf5y3liv0afZ9fCQ==,type:str]
+valuations:
+    - description: ENC[AES256_GCM,data:lpBTLgZQf8deC418rtHi4qgii/zxyrVAvU5UmEHsxJDE3AtCq9MPBpyM+ADZLMYr3KqB,iv:Zxl0nKMkMDhvrDEpFGH70VLL+5c+PzVwbxcqdjmGgxM=,tag:EiOHo/gMv+Sngb+xQSub+w==,type:str]
+      confidentiality: ENC[AES256_GCM,data:dTMN3DI62r0pckpO,iv:bpEHgpLVd85KUR7sp2BvS8+a8TplkocJJcQiqXSzYco=,tag:XsURKES6tjdqJxAZQyZG8g==,type:str]
+      integrity: ENC[AES256_GCM,data:jsoVeU6vQ64=,iv:DNdFE+UkzgGKGdeaXzhtog1gtJ1WEffcswHk3Co/MmE=,tag:VDq+7vgo7ttnbEmCN9kKmw==,type:str]
+      availability: ENC[AES256_GCM,data:JvM/N1FMng==,iv:Cd3J/MMa6sS1D28pKuoDUSesdAggyqbjLWAKKrmat/Q=,tag:Tz8o04iT5NmxjF9zUNOLGA==,type:str]
+    - description: ENC[AES256_GCM,data:NkrLjTHwr0m80y8cfZlM7hZto2nrATiiwIOMR+E4szNVC8EwGaHTzjmRGf9G9BvrclEIYIUnhRI6O0xQ9yr08R4=,iv:AtRtpozs/XkzwwtOP2aSAHrXL9CSPFRY/W+scp8ABkU=,tag:9LyJPKZj3mnLaDJNqhDT3A==,type:str]
+      confidentiality: ENC[AES256_GCM,data:ehcxIg45pZKoWLWmAPWq8eoBsTKk,iv:fhU3VjI6ZOsonVHzJ9JySYgMaIxodemUuqONtzeMbf4=,tag:fn7PTyol/rhM6SXqOOBWrg==,type:str]
+      integrity: ENC[AES256_GCM,data:OSEwxGIRsnU=,iv:xv3KVZT/S2VWQf2vy4Z06+gSdCQVsebqq2u32lczED8=,tag:wctegtVue6s+LAJ5INwZFQ==,type:str]
+      availability: ENC[AES256_GCM,data:KzsfWM9hiA==,iv:ZTxZiZ63qhwoagg7+7TVzgmRMsjSpityWlYL5HGkKco=,tag:i6qEwCB9DNWlUwfSpvqZzA==,type:str]
+    - description: ENC[AES256_GCM,data:GVzFu4P69XJWDpbXp524ZkoTb0O6NLn8Ybl11w4LdgIgaWOe81Dx0gdCg2ciTmQeEmWp1amIYn2F1/AIcj9DgtHIKnXtzBX8cS6oSglTPk3ZAtA+479CbEH7,iv:ks/eOKyXgdxkg9d2s6cFbAeYah7M46lJsBDSSZ9tb6o=,tag:Ko2YCBxWbTtRdYOuFfXA9A==,type:str]
+      confidentiality: ENC[AES256_GCM,data:zX66Sd1CnGc=,iv:VhpywuRaC8epIhmufv6lZ/pdW1hETEhPwgBAQFis+d4=,tag:Y3lTSb4YWDD5aMjDXq6QEw==,type:str]
+      integrity: ENC[AES256_GCM,data:937xQv3Megk=,iv:CSZ03bzPqHnQeLdEh9dBRb0rj8tQW50Sm9Lm3TYz3mo=,tag:w0rR6SvTTqcEQG3sK2CnVg==,type:str]
+      availability: ENC[AES256_GCM,data:EBRK8I6e,iv:3zVX21LKTtNk5OzuoxOMHMKibSNr2TA3NxkSarj9Fpg=,tag:L5ZckoXfpcH2auPb1+AhQg==,type:str]
+scenarios:
+    - scenario:
+        ID: ENC[AES256_GCM,data:2xhNgwA=,iv:jpkpZDEKYIKxE6ki92BZErmZjtocAGMcPNZ8Q1lFCkQ=,tag:t2lfYl9IrReUaJbcDJx4KA==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:MMFtoOo=,iv:8eUTWFiDmr623uyiKE9GzApZZT835qhhd6ghZhyxYAU=,tag:N91CQEMmyIkY2D/7QJUKJQ==,type:str]
+                description: ENC[AES256_GCM,data:LhSH5WtVHzLMVjP+Wxo6W81reaEqc/yudXJGcM2XvVtgqDvdu9n8uwJ2CkzKjazPfkUbK70n6QPPqViopUzpJgEcuzhuiXWBpFSeBWmIXqCABPl5tQcuY6TOyU1XXxmeGGmc68saXQ8AumSuv8XX/XAyujwqA2vQn1r1Zo58zLgLZ8sZp1BHbF2aU6RtWzFSf7/kN5EPKo/Dcu/X2PVoxrK5IkzClPBS4bFtN5JyR2n8OP91EhU5adaUkgpKLp79eJjCcLpdX0eZuG2q7cSDP8QevevS6vr+SElNnc95k7N+5QA23jqQOHwIpH5rOoq/Owbi3+Nyzz+OvGWxhfTwJ/0+cgwozWFOK4Yv1d6BG3JULpPlPH/hckP6o718350zG93oNe2O,iv:hyx0fCI8F1XaTJk87JeDsAV8RtXqEBHTmzLumSwkDcg=,tag:t99iPwj25ijBk/5e3jA+og==,type:str]
+                status: ENC[AES256_GCM,data:Y7iaGo1O5H0v1eQ=,iv:vdL4I8j2EvDjwqoX4z3NgRw1kJ7P/F0wAyRng1avxkk=,tag:hDzrGrBECWo0oSVK1E0Jng==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:b/b0LTTSrvxkOD3zST0iCyAbirtgZFw=,iv:BkByPcgs0L6W32N8xoUfJM0IOkpHikxvhSaIb1Od1Bk=,tag:2OstVV28idUDRHkpTtWmlA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Sz4xo9A=,iv:M+vKX+v3QPYyadlq3N8ghxyroM013Ohff4C3Nk2EKmQ=,tag:Z6YgXe8X7G2KPbiZRveSHw==,type:str]
+                description: ENC[AES256_GCM,data:rXsoHGPYDAar76K9+/VY75ZZmpngeNIRAdZjqYDqFByYh1ftopRV4cFhZGlUoAVssqvyOe+q+R9mPtI8iu31ky7tw4GSi41uzNJ8yhnFVXgVi2xeaQPyvR3XP5a3IKXNRG7dIR/U1uCqDM5OOFaOfj5QMSswhW3Xkwzeo9t12E5ywgG3Hbiv0AI4r+SRDAk5XpHtYVjLOTBHMBBZrw6gaaRI0h5ZneILaHpnxiV1+xOFPPWKHebC+Zqq+djZodsyQeNwjicHm7pRGx9GD2Wa4QVPX32FGx0dLIOInAmOrgKydqXdNs3mMUoMWkTETP056U7lbaWdnjU/0pCzl/hP7Gkmndq198RxMbnHA9U3sWErl0TGUK+0OZAob2MlfrMaGtwWKGMyPo+ZgtS0grTJJwDxCcWMLM+IzTs+TG8+eTtqfbYC6YlU3nYi/BPOKTAJscSZbYpvDb3Mk3qIJp5kE3/FAA==,iv:Q3jjOdNX4CZFPZ0CyHJu6Ay7OmsOOgQJvJgKcehnD8A=,tag:WcLFUr4/QxMCjxv9V0DfAg==,type:str]
+                status: ENC[AES256_GCM,data:5z004t/YxFdOc9U=,iv:Y7cfYOAoqZj9YO/fN+JnZL+EYA1BvSe66Bgaoc4cVoU=,tag:K20HyiGsSC5Y3wrx+yQ6vw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:wvLYAHxf/JvGm3D6x1gqYGjMs6xxa1Z7L8c=,iv:Q37pxI73kyqEVFqc615W6AjDZvDecbM/qz7qwglhRmI=,tag:KhvIb477Nl5iLj782+Dv8w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:EIOqVn0=,iv:eTfeQBbdK48/NW+LqrTdzsRHN6juIVdxnVXsXsWDMf0=,tag:8yR5PjmsktdEHFyb5LkqMQ==,type:str]
+                description: ENC[AES256_GCM,data:slnubt2y99Vz3igwJSqMt+lWYfNISkZ71IQep59v6KcgoHzFnNPc8FP4JnShrJhSWjOeSMLNy6vWdnxjkLC4TKD5Y6fKogXvsdmSNzTH3uh4euEaZHRy8litt+aRQNKVZLOz1v5T1w65hc2f7YkAKKjeUpJFGI1Wp70A5kQ0Fufh/+4kvcPVpcdU/EkfLyOKsY2al9Ep2P4i1FA8E8z4tEC5YtYpFcStlLbfI+k8Wsf6+zhf0DECzd0Oj26ouPG3oEMrTCduKNDYVERPCcAfdCx6Qg==,iv:Xp1pzS7F0KyWayYJoAhfl+/ew8ZFkZxIoe/ez/Z/qoQ=,tag:tmCnWEnTSjRTTvK5maazWA==,type:str]
+                status: ENC[AES256_GCM,data:bXW1TbFZ6ArN0EM=,iv:auooNpVBsisphNJEwrVNOY4qvXRQSQH1WYaX2FU5RDc=,tag:Kv4mKzNZdtcC+aNRdhrqYw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:NEf8nItWE9ySmMDFm/mZLgiDhvIeWg==,iv:pkaqzRE917EjN9Ht6PvUaOfzEm3Ya36OBej8Nx4yCv4=,tag:82M1yA4Bs9Dm2imdilJQBw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Ic8k70Y=,iv:z3LRhvuUXsVSSAaBo4LrnMsO8UiGcKCUADqhs8/X+p0=,tag:tcO3Am67b+MqOnL7nPDnKg==,type:str]
+                description: ENC[AES256_GCM,data:lbnrDd+pEjD65yzdqh4icjblKTRewBl/Vg4b14GR/2GPQ0bTkMbaRZ+hwz/BbHQw3J2MtHCcFNVn8CkQ4Jm1zPEs3YZ3l3RsGx3FbWgJIQmpU3yb1Tz1GfjaxnFw6yJgncWDYG5M/68LTi7k69Mj8dr8iB0hdULYgniElYMGfbS3FCQicI6Y8UtU9NfxRoK+9RbDSDDgPyJSKF/oqw35lTMgnw78p7kdUxDW1Kcv4YGAdUivoZewSQJcXcv1p1TBojvLOVXdS6cQfGDnOH01qO33KLWvoOm9jZP+1GBTgQHm4tggA9S25v2pNSVuTmELARghBG9kPomNNXGOCtILCDjJZV2nUqpjr2ljM++5BXi0Es0Ee8KD7DRcp3pIz8EZMVHXtX/vtxfbPaCKei73gXWietLnALYmgAg5UiBcCO+OelXUWW/LcjYIQ9VJBvapVnAC9wvyUPb++3qGKR0kUS2Te8WeV1Pob/J16kTHzfYTkwjGattK4pTgxzouqymT4mJ3yS9rmh6OaXaReRqRvz497eef3I4AP66wsx9mOGnYhba+/KXSPRotWtdKAw==,iv:BkLLXF1qvq/As4jsYBSuwPKHKLDEhDw4/15TdwYXgtk=,tag:GswgRfVJ6QFJGdrbpOZPSw==,type:str]
+                status: ENC[AES256_GCM,data:2ZKFNsd9bd191v4=,iv:jcD9O8Oj2GPPJRKt4ojTBk3G+cYY9RV9XYUxAT/Cpew=,tag:Gw6tNAtsuxZv6zzye2cUdQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:4jzCVXX6Sat8TRr7TILXdVa8dLkdwj0=,iv:n/VwNrrb7Xn6HrXRNHJIwqLAZC4ch5durK/DcTPub4c=,tag:yxWrYszpUSFQMBEOONkDzg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:po4SoZQ=,iv:prc2XT0jhzNgGNuDoJJitV3HS4xQMr3PjTpgLPaz4EA=,tag:81urpm1E1eQZLdI24cJQpg==,type:str]
+                description: ENC[AES256_GCM,data:3INNRANhIAohoknqfzKgXtX/TaYE3h2W7/NCj9qyY9BB2bHj6lPPEXMtupvsOWMFYQM4gaj8fz36kmQWcAq+L5LwFkdXkQQqzf3ALDVYMTXzgqb2FzSR00ovVa1wvf2ySn3d7xqtU4VXVcgB88vpZZbDAXd49FFbCTK5RAgheqxES/62g6LDwua3fYxPjLf4E6JXYE/L9AuIrwerOxGnSkSyNO1jIxKRnUEC84tk26LynE7cqsgyw5A/DEJDXxO0uWs0lEF9bf5Q2ecUuz3+vHM5gwJpEnRmo6JtnaEqmZhmd/I0vRM7y/TvNAcp8OPVwWcYzK5KXfr72qZQ6MsaauMT9Y6MimnG94bdbY2/ieEMyopar6ZGJ3D8nkvSWoDh/VxxAJfabfkBGbshuGvy20nXl2+NMWgYx2ZDfw==,iv:WtuWpJWL13rqJtSnHsbeh8hMsop5iOGLNBvewVtsdps=,tag:EqMiCZ88677gLblKg7unhA==,type:str]
+                status: ENC[AES256_GCM,data:K9O7OD45l/dOCq8=,iv:bHIfzZoOPq/xHsINt4NQVcrud9fkgt/46o2PmTronTE=,tag:uqf53/CTQ7QFYe0GOMAGtA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:f8h8gJ5X82WJJOK214bd2iVAOrjnD9KlYGnFsA==,iv:RVNq2jB5psxSUiwpZhqr958pry9cuy1WAiaYtMxCks0=,tag:ayojHsO+Mv9dr3ZBNWIkSg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:3JgyVHA=,iv:r//CLiiv+j0hl9swk4VdJwiI/VpxMXWYq6Qx1QbPcrU=,tag:6khGP3RcApUpbUA9J7I5aA==,type:str]
+                description: ENC[AES256_GCM,data:+UnnG6pOVLkcl+X4Hmv7FV0JLwWXIR1b9i6sGPQmbf3a5aIf1OIhMiED/akL8sCRgAtFQyOqlhgeusGsESOiEOn8f56z4wcS0xWO5fzSeTjcyZqKq85fsOm0u2TDWCqbCx2zAp6xLsZsYhoE3G9NrgVFmyYuMtS+IubTLMvaJomHxrFvL6Z/tkyVyv2xmCABJiJJCcUiYi7bRQsom/Wl7a0AC6LSWOSi5k8i1NsEChw1q6Lf8u9jatf2vjAvwkYY4GWidk+G0kxEQPvPjhfH9DlEZvYJl4+wH96O6RjikXfjt2WTPOtpf82WBPcNihw2oymkANESLFcA3MvfRMpxCzYXboMwGJcayrboFZRHXOkhItyZ,iv:9UQBBzoOCiiE9UFR91LLHV6oUdE4l1YT/egpkT/+AP0=,tag:Ps9ykZIxqwOxcx+JkwMM9Q==,type:str]
+                status: ENC[AES256_GCM,data:d/3bVV1+ZGS5MZg=,iv:vHUF+QCRpBnKNB/4hcFCYwfiuY1I0iPyl67o+sS02JY=,tag:XJ6XsUU1wc1Vn5C4a0qTSQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:BPgRBMKbxsHF9QP35s3khQ==,iv:ApynlWRzIIxdmTIqI6PE/0F8p0rDYT7AAy3pTkdshG0=,tag:76uXhbB9PT94ofVwD/NIjw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:FpBe+Ms=,iv:qLvRaIe1/X2J0Td6jGAQMjJ5tRu33izuVXB54BVkaBE=,tag:Mjzp548y1F/yHPh186V0SQ==,type:str]
+                description: ENC[AES256_GCM,data:DKDbQMj+Qtg7o2kweIgCKelp/w/UMOhMesktRX06KWDbXkQ/yu4JhmQDP7q9qR8YlVwYiwo3MLUO8Fwby4IV+T18Ejck9VPWxEaim1LWlDoNc7DMknevO0tUs+hDNwrVJR7S9cAWcYNfR5NdUv+mopEf1CxUUbjkoX4Q+C96BJwLXhOC2YoCFxzTWSM0UPj3+iiTbYD/k6Sf/W5EmsSMJsv/8yMYuzkpCjam1QGjA/rT22342THN9wujbS6RPAwgZwG09XphdgLaF7FEiyBh6gMM3vfzOn62ElCP3tjcJ7/F9zAusAlGlxlbg12iZPU1v0SVrrOwV+U64Kle2jq0Wia1dGK68wilRtvWp54tsFYujyR7EixhrPpKvEkDqCTBedIq4ZgGxKAKC6l4AGhQjPfECjsIWNmNh9iWO2csHDmQ+C3Sp7ADRQGqqV5ue3m5cfTnOonLlcRGvIdrWV2lc29/pEyW1PgU6CCknlv5bJlbymXtsWp8yZjT8T38t3gCYg==,iv:sVANS1xswUTtPXO+anRkJ0qoYWSGvWC/IYgz7s+teME=,tag:llqfPyHbs8X8s5w/lfIxrg==,type:str]
+                status: ENC[AES256_GCM,data:5JlSRpqU99KBs4I=,iv:2PmtbLDwNrAFEQpV2XuU7f8PIlMcVMqKzY27QAdHE1Q=,tag:t16Y135a2PiqKlV+eYrs8Q==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:yjlJTOvt5IBsOCm9f5fKAVolUorC8xA=,iv:pdl/8NnMWaA1i7W3Ji9LEHTXUHvOmR0xGuNMxV4C1Fg=,tag:AT5r0l4Zwci+0mnhEHz0fg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:AKwol0k=,iv:OEkA6lkgn8LDUowQBntOfic3nu1Dw1ulXpHxe6V5Fuw=,tag:WgEXGvkvhQzGIB4G4L78TA==,type:str]
+                description: ENC[AES256_GCM,data:sejkKSMBK2q9kjr0EzX1Xdbc62GxS1LIxKcXTWwo1DV9XLwAoRqJ4ywQUmy/85rtGpOmrCO5lc1mB8LX9ws2+BHRYV3JsPYONXR6pux1qaOn6jc+NBam3knHG1mWxFEa/p9UJSnrsja6xKqPOWT7tsZLTKQkkSuNEoxoucQ5m3KhpJK/jVLDY/lnWOPJ+nEAuYlIxQtuVfVP6c/TvueXff2YQ2gwS+OoAtIM8pDvywRNYTSW4oyDmg==,iv:RqAqXQZ2QUbMxMdd5i6VSUFWArhonSf+3oFuXZD7FWk=,tag:Ai/0SYzdQgI4CJwhWmgPuQ==,type:str]
+                status: ENC[AES256_GCM,data:6v1zryxXYIYRobk=,iv:6x4E/5864VRbGQf8uv5skIaLZeVca3IQ6Oq1KM59NsI=,tag:id4cPdnxCSkPq+qTORL4mg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:hKVxYvXajO9y9gZ7QmfLVVgxBaTcCdOhY60Yf4ZGjA==,iv:hFp7ZNWePjrjvXF7xUbXGlGSP9dYzCekPgBs1yjzo4E=,tag:zEJVGTdwqIkoG8hhmNfetQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:19LfXeM=,iv:FZU+5nfT0J3KH+YSvE+1HTVnjpKosNyCcFA1JXFXU1w=,tag:I9KJpboa+YZNvLTIEDXGhQ==,type:str]
+                description: ENC[AES256_GCM,data:LUjxSdQ0wFsBwIep+NEF4mhTDgpYde7e8X/jXfm6jr5YSnuFJmDRJtaVrtAZT8vyFmQHwMmZI/FZydhvPaW1Hp0hDU488lTU5h3UrGel14Umd0p0huteSFIM4jpGBLEZ+bXWao0YH0w8nYJicM6HPC/FrWSjxTm9TMXlJ1hvrgJi0Y95Ht24R1koR7s8G+yjPyElKLMqWfF08O8vl3/4MpEu4B2L+nlgq+op7/7dI2Zveing3X+dqE85X+rNLsHgnlMd8F3SETJpc6TCgNOMzk2mTA+nJayQzXqbnA0lXDc932KkinQTDmWFkeFaOxRCELTuf6AMDF4tBEh8aSNghzfKMb9mMrj+ql9eLUKBxgqY/2/sCz+3FEeJlKB1MTP7BOokAbY9xajhDSqzD1k8yB3hUS0L1bb1lRuCSWJC3lDdK5Zl1EOyZ16l7cNB9OLFWHYEDvi8hgk/l9RMPv3aXNLYGUcsPw928CCwsw2Dxw0jrXJbZXdJbf2nFbEpxzK79zDPUQakfBWw2OxWaJvjMKB1Iztjo5ZTo8d5DkeUwBsErK4rpl93QtRmaD8GWJGNlGrZ3SGr75KAN86ehDDdRTGdtGmUFCIPVwBh0MNYxSC+7irWpI1ciB8h+hrSL81npvxoLtmfaumhXEobQqhDpt7IZ+GReOUr2rfXo9zTjJxJWXMPqnwvqOGqAm10UR/i7QvX+Y/mJo3J+v6AUfORjlPtvtxwbtJZl/9/AYm6wTFSoD85j1hcKVUSy+FeL1H8Xq5cMYonnzlTWkwxmog0TEjOSfVy1bO2Xb+q0aQI3PME7PVw3sekrRjmWk4UMB8xugES5n3o77otKvWlIJtPhcBuIe4I6h6pWApPZstkzmBzbIwcxfJvPJ5XcD8cYWVuaeoz/mMUxDkoeSiBo20jYeEIX4Hd66RtnD0asBZ5IvXXtBUUGfEtqWRy/dlF+RVmanw+WLdx0OzzPr9LeH3NwCNVAfa1Vygz90clHbl7Ct8dQes4A29/gm91WdxnssW9LBPtBoFfKAcFehCaGhXsg34KsWGZVcVS7D+PRemkbjqj62xdGk1Yoclurs6sBibtTm9o5ujL9H+Sxt9nhaouw3yj9QFNSBMwGhxFq3tvPuVQH9AIr/BMPvIjprcgFeJUnHs9MirHMOMzvSlYL/NbcT0rcPhb9voR0Q+EMDhJ9Q4Y4jwabobnGMUd0QM9jKbbl9rWAIRXmB+OS+nPYPTf797Kbdjuz62v2j/VfPTdsHv2V8aJlj7bqOA6s2lbB50jB8d3KkiGXMcYiM7v3+Qqf3aNE0P35MeIY+4tBoOtXbRg,iv:hDgPNqoebSYt19TJG9mcO7zMQtAl6Kj3LRpJOrDw9DM=,tag:qC88O8ZLAMuhROC3EvXbxg==,type:str]
+                status: ENC[AES256_GCM,data:Jp2Xyo3gfoIAYoo=,iv:PnR36GAMihkLfg7bWmw4paad1D0BcwruWZisAc/kXFE=,tag:7YOly3PmkyJai2soeHuAsw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:ablx805GHbkUYuJZRn5oNxwo/ZRl8X7Cr1CK2w==,iv:E2SuLEm7FGoWYOZeVMcfgWlGDe8FY/V1g6Oy9x2bMvw=,tag:EHl3kSkZIbL/XqY5qbzoSA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:uZ09Ce8=,iv:r0HL0xqJpLp/ZFwawzxYLeagXcQg3HrY71h0dZaw9ew=,tag:JdqP4sbJC7tCmizevTh9Lg==,type:str]
+                description: ENC[AES256_GCM,data:Oqzte0TCSAT9RVw9x5lHfZDkhTQ/ZE8gjQ4mh5nkGzMwQJnhCt45Wh8chH5eoffSf9msBll296hIZYTS5yjeG6SNSOLXnqwG72V0BdcCHdI0+WVJ2UTNtAF2IYHfz7e7KYALMND5zrzsYZpGRqfCX57vEHRq4oLSf2H8jzDhbUUUyzSi1KB1+PMtSLk4xj28AlA2NTufOnx5M0qA7k9b+tRFRwjECEspdjewSoCQrVqWw8a3fpo0vwvDLRnJYlLoeuCKQiMf3wAmZGHZCA==,iv:giVfJoEOXCTw0/33vgLjNuw0AxtviDHI2BEZuyKkoUY=,tag:w9sOP/P1qiK5vP/qD5zC+g==,type:str]
+                status: ENC[AES256_GCM,data:i1BXrKJN1ttGSjk=,iv:IM+ewNlUiHFZ0fnbdZQCZx57J9mzATzeYg5H2tDQ06o=,tag:mQwaT6tdhpL+ji4E8OI9tQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:69vxQNDHUCsCsVBXClsVR97G5PJANyrKssEty69g,iv:jA2zuT7CB+O/YUsN27Miwc1KP5h3+Jk/M+LDecAI7jE=,tag:8c2p91YBzNncOwWP/XbHGQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:wNmJAbo=,iv:TY/Lj8bOmJsmKnWbx8x9T6LJsTt63hNgFyunug+15uc=,tag:CspN8ZRRgHpGa9zr3XAPMA==,type:str]
+                description: ENC[AES256_GCM,data:OudPrbnJTwjPnyg0GCXG0ZUm21oyjSXgu5Fd5IM5rABYtQelQcqsge01qqocIJEEQstZ25lq0+S51bcsmog/xkF+6hZ7jBrMyHKHKqffSWWlA+ur782dGAH1f4O8ZiQFqv8uNRiODSa5JOrwdpiFBoS2hWdoXAQ+gqABs9iFipnvFl8keBFxt4OIhoTxc2WJ4/aB8RP7t6pMuT2jNl5Rpsr9CDjK5CzMgCAA9jKfsMazvElhgKj2MF7blGl948sQ2b6J9BnscPTBoD2AAAdSTBrq3zqwH/++JqIwC0FKEVltI7CtfxQAWMHURdpJw+f4l+/7294ZA8zbS1bILb2/C3IA15w43s8kPWLgSm6oc1tMNCcLxHyqPC87SFviR9Yd+RxGok1LU/yM,iv:t2Q8maBP7r2ykUMTEZqQ1xcojC9+XEeb4eWKGA5K9Mc=,tag:j3AVzv4jBLcO5hn9TSQxDQ==,type:str]
+                status: ENC[AES256_GCM,data:WTHkBnzqZv9s2AQ=,iv:KT1pP5FnbxNOt4Ie7ZSh+AD0pTmyEZlau6gOKmKe8cI=,tag:RR23kU8zeDli4RM7B9hUdQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:BUXwIjt8AEpHc7AkIEeJZkO2,iv:6sgTvJTuZ8CAYuTGX2LMzOuwCKgxfvwlr5KI4PTM8S4=,tag:fM1wvHRm/wBvs9sdbrCbCw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:w+arXgQ=,iv:cIuUpdeIH2bt0zPGGVnvOAYOO8ODzW4s2YAth00GX5M=,tag:+wsrPcXR2mU3TehDvzOzVw==,type:str]
+                description: ENC[AES256_GCM,data:m9VfXFstNv2jq1HoUR0t4XLppeM2dIZJPrtIWlti43MSpMJZZ7iZUhQTn17b09ndpsrE2wwaF2ktTJEn7OAp69d4/8qElKBl5ElrRnGMagWrY+zjwVDn20esjz8q3iz342Mj2gICuOiNrOCVfKzTTaizSmkSKEtjaNkwooC6q6ld+x16LGKScx9l6TSpIU8V3Cv+iCYqeLpvQvb4S8RVZ9x3/J0xvYvDox6SloEqXN+gGoYegt4gcegPpaRWKvxEtd/n5G1jh+nw9m6bf3stWG64C5T0seX2qcU3Wr/73gt2qglBFhVCJMn8dok9TkyyGFZzNkePW5mdME0MeHVgNBw6raHYO2/83m01YOEcXZIBaBnj5QPVbTHzuu6ksXkD8EAcEoSyPX7L9fRxaybx7RA8qImxjTa818MTr/CLnDGuCNRg8NK8wNwdNvzNz8Fkm/Er3Sp5bWdKPw3/6gA1jPGRdYSSmAFytHtM5tso/TMk+gauRBA5xsWQup9J,iv:eaq6v2z5dvoBRYMvzfW+ziNHp+WAlP2OwOqWDjQCWSk=,tag:AL/f+KP+Mhn7loKD0xGBbg==,type:str]
+                status: ENC[AES256_GCM,data:+gsBLD5xFugyC7M=,iv:6azWZYnmvf49E/MSxkZ1IHye013HetEhF1zmyBmL+ug=,tag:9iqybwkrKLom+c5+BqmC6g==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:dAN7IWTh7fhzjgNd+fVoy84TK1K7UtaLxY46fUo6RUvhLA==,iv:fl1gbTccJKpiG16EaRnRxPbTsb/Mf+h0aMdi72qn+pE=,tag:yMPvwL9RfUJbzycZQTpa9w==,type:str]
+        description: ENC[AES256_GCM,data:JTH8ofgJWpnfTg0wsG7r8oYwNXjfVBr/bxNvC4Otl86KejTZUX5pZ1Rjwhvyb/rj+Q4CSppdCuPlZ6mjnZvPo59jwkDLmDFg+t1ouD/RHouLrup4a1etlGz6vug+fLOqLyGubROCD/V/74rEMok0hUfMf/HKnn69+cV31bD/ptXURiNhMlOK+MBYlV8wbZjCgFKvHzT7DvaU5j5H6OW9tbQJ5Bpatchird9Wna2Wz0tEa7gRoz14lEdhLCpdslDs4LfES/GZM464t6Cevn0l0PwwuUO6bOP/q9ptxGLX5ijUBSWRfYGiiSjSIN/GMb1+NkpOXk9H1SY2VOSwxWMntURSGXoJ7VlwU2kWPwS1Zcv+JEwoyw==,iv:/e5gf2/x645Uy3Y1I+//cLWlLXqFlKgSdIMnj63U0KM=,tag:b0ulHpj6UnWLhgXX9Y44cw==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:5wrBsAFurA==,iv:eEu/gZB27oEMIfXNdrwLizNujiSGwX2wTe2ALI1aL+Q=,tag:eTO86TAl7bwhrEYZsxHTdw==,type:int]
+            probability: ENC[AES256_GCM,data:7Wz/Ow==,iv:O3LzWJjVhA0Fp7N/OVIUOI0F3Wj6R8djqebXcR59nJo=,tag:d0Kn5O3SeN+L6klY3QHBVw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:2WU8n/ixAA==,iv:Z2jwYs9Vfd1uVCAVgtFknp9zJ9A0maQoMrbMSdApKhc=,tag:aYLJB6Y9VY/N9uTFfHhuNQ==,type:int]
+            probability: ENC[AES256_GCM,data:9w==,iv:CJzzfSTQko1znsec9X56k4njdvZWMxOJJ2QcI4NAWn8=,tag:Jpqx/+Gj/aHtcFajlhjOXA==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:ArE/rBCzZ1ALofsR5XGacsU=,iv:HoCEGb/O0Y4i4oaGHODQo9otbMy/v1s8SMdHSdvF4BM=,tag:b5hPnsLO9PS9HEU85mA+Rg==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:TcyxfDrAIrlNlfQ9tkLCpw==,iv:UzL4l0xyhEhJeTa2eosmsDuWYyHAzu//xV4IyU7RW30=,tag:TKsBK/EGvvUNNjIXlFQbOA==,type:str]
+            - ENC[AES256_GCM,data:iWiWTFQEwv0aDlurIA==,iv:kV1kXU6M4vyvdcl8d30uZJX690f8maK4gj+Ybxm3HgU=,tag:yhmOFPZ0fi53VmFXkwUKOg==,type:str]
+      title: ENC[AES256_GCM,data:C19kXShdSzbJIpgMFlJGbujN/Mk1YowvDLEHH085H97x1sYKpCCk4q6kK+50e6KZA3y4jdXQNdUFHw==,iv:Wkpgspr6UoxKeF+M511vNKcTJfCSn4ItQ8upDUErrm8=,tag:zMYsc1/zIYqr4GZ5FYZ4mw==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:FIEH7pA=,iv:j2HhQz+EEnL9fpjo3dpRCCzyzQwq8zBdPB38p5OtBGk=,tag:X0YdOTKaFRIFyMSOiRhd+A==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:Pi/mhh0=,iv:/q64d6sT80/OWUwdgQSqCVNFeOCavpEfbKKJ0b5TZ7M=,tag:vkjk69MsRs3RaJFhQ83tIQ==,type:str]
+                description: ENC[AES256_GCM,data:8QYXn0HjLMHS4Q2IqogUljv++uDYN7p6+WK+jQWMMkTns6EhIbzQEvjOOUyd06nMRye/DP9N4OrL03fBOjGd3LHXhyouTdMO1WCJHzjB7M7ABIY8SDbine4SIwko2sXz7sBw2FopvDrMRwSq2ZFfmknXKwDqdPYoE8WQTGxrOYRStDuSSS1cjfxzuw01zx/9PiTGmW6DRHRHj25sfHx0yL4AehU4PYXqCgwvCA66MqufA9YwhQCfNXBlzYhnxzVbBhYLeSfMMMJtMlFJdn7Ia4m5NI0zY3XwGBbTY69pfOeXsShxnSGH4CGfAuOR/qlXZD0BNUbfShOu0BWuQIm0b6NAzQftT6QTucVKB7tZjIRs,iv:+Y1DPAGNrW9pdJ7DJhoBPLhFPqObe76mu7OXjw+Wtp4=,tag:ZBJ7yC70K35ccJa+/TQihw==,type:str]
+                status: ENC[AES256_GCM,data:SqCq/4+07fC7jvc=,iv:QxvBjCYJb3o+nUKux+mFVXwxDu3dd79zPf9EODhvnjs=,tag:DZee0NOqFL3jqcmxgWF6GA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:yBHjW4+SnCUsR96cCnuw9zALnLCRYA==,iv:MhinhW+/kAKnt5tW2eUSc+Y8/oU5aFwpjCqK9vCtj2w=,tag:Dn91HBZnB+mQ9kD0fVp4Jw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:1vFIfCU=,iv:eY2xPHqW09lMu9p5baVzr/fRHQoWAW9IjPz/3psixnE=,tag:C5T7Xh9GpFAo/wMfKQy5fQ==,type:str]
+                description: ENC[AES256_GCM,data:7S5U1My7+X64v3GVvXIO+1Txkah7uJOO8jrRnr+lstyCjnxs7kIPmlQvbzBI4v9jPPp3XyZoBr/hQBZqlN/FkvvosTLH4c6XJot3AVOF6XsDagAQVHarjT6Z5wHwQlEb1NH30kF6vheMyGu+y/U8eBRiEugEqvD5Y6MY3X6vtxYj8XswKzWTX2jioMg39mi8Z1b74bqsRwjMq0VVMi9OpG0gA1H/jxDrg3iKj3cjpFd3S1Ei5tNKe2yhSDUAdU3TMO26kbmvpU+IYQwT87JZkF8CMOj3Kcls6Fhso9sfknbzK5uam3KufyzmIDpWwP3dAcMKclZJXrNz7Y3/NuAVVUiXFbS5NgnWM5PgiL3E19RJN/5V0ttB7qVHQJyDNj9uilzwh3xK5ciK8wHZX7FyldBiMPCafd5bwVbbjdGWpWlV7rQlCj6DOI1baqHUNrKJI7RDEsFtcaf00RSc6aNDfZdEpQrIm7BUb2em8bTvSnOMZ7c=,iv:UeVb4tipo79xOvNb8vnIbtN5WM7iW4Tf+uX6L2AeSWs=,tag:E9Zv2jC/UdUlGlw++ugnTg==,type:str]
+                status: ENC[AES256_GCM,data:a61I6ES/WtDz9Yo=,iv:b1MRc0/f0AX+49PBM+dLwvgrUL2tKyvsoYJfY0rZTeE=,tag:EUn6eWaBNTP3OdQ3ix/bgA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:TxiOIsqP6FOTeGSgnOwp7NBtyx5Vnis9,iv:E6r/AkBQxZMbzJC/gpK5qXa9EDAblxT6HdWTr4lJYhU=,tag:sD/EAtNPZbGtbhh5vqP5Iw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:yi8bZN0=,iv:Edk+XvWLIcn7Ve2c1Mw8AJMsjWzkWVcl2j8bojMvApE=,tag:EktR4JvfJfdzrObt4VdOig==,type:str]
+                description: ENC[AES256_GCM,data:L59tv43X6hb2KKRnW/HtXgWMx2SBGMum34edXb/fwGCjqRnu81ycht5pLOrVBPT4HbJ4GJQIie4hGqO2bMylejGXvflce5tvlHuzNMB/M53wRDTKU6wk2OmwIln6dWg3Ecm9nJyXyaNaAAlDsjH4SjL74SOvCLwHYSRkoUKwHkBvd1mX1TSaEcCdQz9Diuhh/33/lVbf9zdFBna73/Via9X1hgq6XCqnFgS9rVFN9fdiXplvUg6XT0+bpOnxpiixAk05iqIu5iYIoQBdLPZN3GfuhmoDyXQbKm+fGSbh08J/pB+hOb9xaEnXMZAf1tpWT9TlThpAHoEdKKiGbDgSAi5KU0EErnfXhwMIsk1FhEmGYqbydkPmfJC1ClYqY57TNlisWm11bNa7kCbtOVotd+l5jfiVaa9vA5dGIBR5JBNkc8UWgIpNoWjzZLVEDeNvcHMDYNGMdmxisrriuOB/b8CZyEXuFutkzdb8KpzGh2wfbj7NLtOMSCBNcDwtLXy9nSuBGXqOM2euwhPRgmoGDxx39EqJ0IKUwYLI9raiHUrwWjyYxHpv0J1uqhSR9uqpKqGitNuQVwaTo3Td,iv:vnFXZ036yRXkh1b5iduYZElBV9AYkPMTstBlAAnvmwY=,tag:jF3W3dcSsAMeAAltbaOs4Q==,type:str]
+                status: ENC[AES256_GCM,data:yjvKl78yc254Mto=,iv:ogmVkFqjUxNtPT/mnbtxp6pzHYCvAfW94CfYwvUnAaI=,tag:TdiiCFXN4hVdeGYneQvLnQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:obDIQBM+XWSf58FRuDjBpHbHzM27eMA=,iv:MRqaPA1lFgLLbnVdzBwhM+qCn96HHst2ZK5ZV0LPjkU=,tag:PGFVPuvxEQXmP1fvq/r8vw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:kAI6f0A=,iv:3J9G0+TH0cbHDMHyRpFmXdXOCPgMM+4QAd66WvbkaAg=,tag:1AjXIgQ6pooA0ktP3SEgmw==,type:str]
+                description: ENC[AES256_GCM,data:uV8yXybU4FvdfFaZsXF+Z5mM/dXv8YCHChof2kgolw7vpdH/wTMZgvNAPxvKdOMMQbiclyrbbfw+gQHEg/nMdH9WsASyNSVek7PlLe3Ve1tRa8BG5B4Xssd9nJPjQKW6iK0fvwDTWBzuTiEHe63FQWos/0Zv1kT0J7Eq5oMNffb0fBiUltexMrMYeUMBC1uEzi0kunrzh/J7O/Vnvev4E/aEvjfS4H44gpzxjxq6cs0/qDjZP4j43ZMit6RhI9372nIDkbd/hGAvP5dU9VERhwpWUDRVSPAFKtFERE4xYEq0cDV9A1E9OJpf2J1o5RuZZ+CC6pEr/dK1ZSl2ra9C7R6P5c1XvoWeZXBwUKqGLhaDWnenIQruB5QVHt0mjjElQcArGelklgSrnnF8c8BnqQkQpLPNThApqRbsVDnqIbbc2zseykxRAg4wzGhyLRVM0NMJFgQfzpMw+m7w1Pxe7Y4LE/Rn5TWL6b4V6cM48EY/dL4NlRkHu6zt1g4mRPJQ3aru71IHfL40xSB9C0fd9beo9cqyoKiYadiM1LPgu73Mt+ZGsltiG3KbzGyj8RBFse8AOFaeC0+R+1DFlpA5RgT6zSp6tAL7IE3ry844Pu0ntCgnttMgg/fJF5ZgUGYgcZ277CJOsE5D4u3tjEj4niycIfRGz2nm7r5FUPFD8Gfr+ZFJ5HqVeG9zDNC7prRZelj/f1x6mMNdkpVQP4JIOK60XhbGCvYLPsFX1d5xj0MPN9tuLhnkgQzPvLlkJbavyjC4zKuq6jCvUzq0OEKNMEbOVJD2xl99OQU/i2Ti2CTRfKzxolNENdTQzCXPh9D8rxZTc/OoCR9S0KUy2w3MlSc3bLWJ16Ic62HSKB1k2dN+PU4ChXFAEs+NinuiQzpCB6GDeA+JW/j+cAm90TKpJJM66mV0n/Mu5B4CenBgxSHIOFOBbtWHJE6hU2OSFqKF8/9Wy+lZCTBGVC4P0HCp6akW7wGsqJmgCTuR1FRCwUzifz7p0Q2iS7dumw==,iv:FInO+4qY63VkUrgGCqFqXODoe6Z/Pd+cdLGFPOKbqQI=,tag:GoE9FiKBlqAMlNnXf6AhSA==,type:str]
+                status: ENC[AES256_GCM,data:aUS9zWH4MInd/pw=,iv:BXOr1c5qJECK8zSXBzXyVoiGZ99rzGg+u7clQdUVhtg=,tag:Chx2E6zIL9QWAuqYbuZN5A==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:C6Qq1ipA2h6bmD4VKNw9ctQ/IDQ=,iv:Pti1aBdEtaDbDI3cyrHl1CtSBPbr84/rIRpadi1fYxo=,tag:4RmXKFXJlLPutmsktrTTig==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:VXa5pGE=,iv:7JN2yTjcse3ADAnbO5Me1mFu60IsdJZ+Hsnc676Um4Q=,tag:v32v+0LkImdN6nSAZ9acdQ==,type:str]
+                description: ENC[AES256_GCM,data:fYn1TvaH1Hb/t0DUaFMPygRf5/u3pd+ixnBjJ8q0Js7HGEjKVEUSKuluSYNDM4Kc6dQOD/SxwlcgzzXUs5hcqSti08+1q2tBNEOeFy4+o/AVrwIUtd8yCreGiVmSSpG5gw0EaVAsF1EvJ2xjHsukKBOWVINLvxDwfO+1TSCu+niPmKEY4a/96fTbvIOUiEBCyvvLHzZ4gpj7yzKYeRrOoWroPE2MYJGXW6ul8BBgbzipjJ6PXvNp/bE/gPy8dCwzzN5oOp7ntrmoVW+0juqMXc3Q1NnN9XK2x1XaSLGB407+ur426i8qhvLZINEW9ft23xptoWOUUGhL+ahoJyt/gqlHmHV2HWP5u+gYBCS+z+hNxQNZS9HjMjGfn0qXYmepxDWuLdaCc6cCPCMv75b7UCBulQdCQIYSodO0SbNHkSHZrQ==,iv:1igiof6bkGmoz63DLl0YzKJjrM4E7NYQOT3mjwAF8Ds=,tag:VG4wL5sEr6ZrdNn2B107FA==,type:str]
+                status: ENC[AES256_GCM,data:8Gsivz7FvrXROo8=,iv:G/dRmdOmvjt19FpTGpJSrCuJ0Ihf0W0rmXab70/SNeA=,tag:N7CsGsHehyIvjkIeadCzLA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:axblCcF0FYImFsAcYWk5cbFngA==,iv:pIyxNlSpYAVe390l1Bx9EScSZog843oYxVI7C8zsHw4=,tag:ynOjSNIcHccVLNRlIVWq0A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:szgKO1g=,iv:5LgGnj2gexSgcwZKR8j4XNqto22IzhlTtXRqJe4KL/I=,tag:Rq+V7FrUbyRDlDrE4Q1Nhg==,type:str]
+                description: ENC[AES256_GCM,data:vPhJ1SszEDNcmC1/n4GTz45RM22AnC6LTNouMMyHqzj8jgbeRB48zj4dxxDfSPPLONxHFmjN0wHW6Ol9ReO/WoVqbP8B643Dg54s0c8DAYQXkBbD6msTgeE+LIud8SRNpyR+wtS1lnBjFPqgA0NZRW9P+yl98y+yN+78irJZK+1qYCe/UoW/INjIzifwTHMGi+hki+a6M/cmyp5jxfNrtfcK1zPjDCJ77VQ1O6AfI7kTYRw+BR7ePZEJYkTPWNtT+Bauea4dL3JGrXInBFkaF9p7FmqCmPI9sgSmV8oAwHqpEdmqobXjoMjShaWsd8nXBnHE+etqC4zPRBM+5xpu+MZrWxiZWD9PR6IE60PYU/uzP2QmfnE9qtsBYp4k/zWcETuz06WWrosiPTwUG+KO8xw9c0ZGoNdIgjXIY+RPoCg1KbOjg/lrBDA/tKQWizEcuIjSStMazcDdNyw4+JBCW0fFVy/mJsDIJny7+KLThAb0U8mi8f/hD3Lyqwp6+2s5a8supLUtO7MNuo9nkDYIyXFd/ak77E3yvXmfaVm+J2vLv5FfyAju8bCHOJ24eNgAuDR0EcRYRhP3mObZhejnjM33ZIHnDJC4NiLy7TEDahYSCIA4GoBulxC/tHelqmAPwAFjpyJGDR7SAfq5vhIvNTDvYm6atUxG1zgBs8E2KKBwQH0MxO9yAWYq4brda133YmG4NKQ0iWJUFVShEiQEJrJ9H8OO6i/Pja8bfP0mNZSPPV4k1dNbqUvmxVAL8pjF6r3fTgQ7YibcDr3BPvA0b6abNVKRitLCQr9g6I/31jt+VO6B0JJ/T297Dz2zgCXlONiLn0V0G/bPNX0seUNvlIvwaIuSARzNVPJkK4T5f4F+H8KaurxvF5Msj6qC6AnBPES+FaQNB9mRaibd67XUuTYdIRd5m0V9SDb9cKKiK3BDeKGDQ7AMOI02nuLttb64RuJbZdDj5ESIaPDYS4KSwj+NuksR1jcusQvkBu8b9lnCioTuuFi9Rufd,iv:bw8XfgsTdo3OV/2kZk8wVNzP7PsaOofy0ksQMe6f+Yw=,tag:94D8FOgfQQjx1QBkCc/gYQ==,type:str]
+                status: ENC[AES256_GCM,data:lntJs4As6yXtJhc=,iv:9ToZbLHizLRUXvulP5sMnN13YJCD/ZSAfZS59eObcug=,tag:dIN1mbR9sXX+WIYWm6/VCg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:swtgnzU4Rx15k8/9OP6b8enyktk=,iv:tMCrFCdfgG+KVjrCalOKGyozq7nJ3pm8Yg8n8Re3ztA=,tag:7P8Nt0H33lWcesDlYQO5jg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:roJy4JA=,iv:QE/dxTuswP/BfK+gyYwqPy/w/nDK1Thl7+XaWZf5qco=,tag:iuOMKpSkMCt5yQ2OH/F07g==,type:str]
+                description: ENC[AES256_GCM,data:mwp8mTDfou2ZwF4vR5/8HCciBNbildBi90j9D+bzSoHHvg5f4Ae1QR6yjeVk2/4BwZzNS5c1x9vtDARQqBmKMXtfI0tAjHzkIsP8s0gC1Q/1KblUQPVLVwNHX18G9aG1G4plaOMa0u1P5sWCUIGLm4gheLm/3PW3pY+Yx5qUKHSG+3qLivUsIeCFYiZ1HhXh35oK2svUjPjArxypPXd4JH05lcR7V+4iXBSn6+D3ZhiH3Q9ritbwRAw1GCChFGkobA9HsSN23LjB9Xc3ZruWTMKMJWxgS1TcIWEHsVQ2hFICGGLyQz+NcMwj8LDiMI3U1xIn5BTngKl0gl5fp4Zs7UYA1S6nxE74yy9Y6HbK27wbOflVNzDgXGbQDNNvrPg6wZPX0nik3k9Imal3iehGL6UwbRWkdykmiQE7rkon0ipAxXQFOxLdKnv96Je9CG0O7Ns2Ui6vwdXPLKNZgxghxBYYxUH7V5o=,iv:G+Zydkk98ngr/GotnZM81yLz/KStYmpU01dsmp1pgeQ=,tag:rGLQXPnafsmQcNIQ5KUkRQ==,type:str]
+                status: ENC[AES256_GCM,data:nESZYerB1OoVuyk=,iv:VejznqxD/Ayh49mLuwQW9DoAavIpZFfLVCMQl8pnzrw=,tag:su9nVNCeukb1wvgrRU5aTQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:DNgGZb3nyUGeab50eCkLcg==,iv:Hh2IU6ZXEttvqvPQ9sPdRUMiRzpk9kJRBgNPOydusro=,tag:ZfgVHtLd27HyhZSoKCP7uw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:2932AxE=,iv:NRqIGLIujhkeOK/GWAxL9aZURJGYY/WPtPoPbqk6iwM=,tag:P525jgD7uQH/n9xwZcOiaA==,type:str]
+                description: ENC[AES256_GCM,data:7Aq3POBfHs5pDGIWfNcJ90+CQgSl7aUnVDBNME5ifE6r5uTVw6Wc+tMYSg5fqybvOhyAcLbyXvYeOoTNNwc7ehhtrDvmoN6D4m/lvLsLJ8agp+r3Nz3979g52CUfvmpKDIr4aaNHvBweH3SRYEa2ndIJTghKjjm+y++5dxFhl8f95rOSO5v5uiBYPYpoeLhll02qbl0CjeSyPQgKAuVML7/TTr+6ppfijzHZJtYLP+sK9XFFZBlq6NPPh7+N9qnfZfv9iTeJPutZw27o99WW34lKnNt4l6k24fcip0dxz87hPwrTwBtG5VBC1FpsUzk2C9zwHMRhgh6vITOmVfyoXylhfGv2bkfAnmvb6EUVbwlCPy9sU7Vcm7QlO3FsygZsQicqB2WkfVd+4Q+oftIEKd2AJkYRa/WEUw5qQwgdOO8ymKCjxxaX8d+i0xtwRMILghsvoyOE3824OoiNM6p6dq581PVua4k=,iv:PUC6Eylu1sIXkAKt85viuicAvZRgAtC10M95VLwKO9s=,tag:LpY3v4MuFJiUh/Mm+V2Inw==,type:str]
+                status: ENC[AES256_GCM,data:ClgBC0PlI6Xf/cc=,iv:u4pEgxz8LV2f9onXt/bjNdNPn22i52h5eLNIderNLTg=,tag:Tbx0R9m1m3/Scgdt/jzx8A==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:5yJsv197iXz8Ja1AvkduUyVPe5p2KGg=,iv:zLyAruA20rDiVpitvOkhZAH0LAI7eHJhzNmSmou0Gbw=,tag:r+eRoieWohwmjIye0xZb3g==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:XjotdQM=,iv:DTLVhw8rjuIiNdSqHlRtnFXJCdX2y9l/8/7yzYQ7aek=,tag:wOsbCq5ejeBXhcyj0xjkmg==,type:str]
+                description: ENC[AES256_GCM,data:zZzglveCi2cTX80n6T6XKCuV8/cw8b6iaKa/K9ysDBR0t+E7enDmf/opehy36iEhcYuYq0iFeX2E01EhmCnChkhpv0qWkK93blV05mMqrC58XumIDAi2hGSgX5uVyF5jm7jOTygTnm7lurVgw0LH8s03qvupaOnsA04MnyxNAnwXohyLZrQkSEzWOvj4Hr/WN8ZxXQwm39l1Gu0Fj0OqQmKH+u4SKFyemZtpmAMe3/4O790EQwVJAcQZ58EgsSy2H4XTAf6s8c+eeXcwILh7+g8Z6dw7fsj3GK+zvhNxR34RHOHwXHCRe93usvvNDUQI+DrYhkli1NuIdTyI/t1y72UUSxRBt17QpfHt3eEJ6UdPP7RhFTEzcP6fkQjQTbM/zul0GiU0hvFqkJaMZ/z21B2OC721RTsJsY8DuvmdMZKLON0BgTN8Bcx16N2oZmFgOjmphMsz51dkJiNU/hlZAMNs85KvPnjg/VZLhWQ4cBXY7Sqhpg04kebN90f+WIZk9woSzOZaeoBo0p1T72b4pMAbALvnrOWvOocyRworsR+2GE8W1HziHNcCQEoiQJL020awRoK///42oWh76IGHM4aU4XPCGFsixdkFYF3dAZ20dRMiZBWPQlyW2uLFIYfp/gRHongVeNBsNHxhl/GW2n6ffZaGvTxOX9SgVs60S9NGa8ImlAPnG0VuVyoKYBfVHIVbD5ZCSymhmh8O0xtyUvy/aTQ3/M+eSJCa2aUR5n+PkjKm5XM2gB9qFLvWWbyqHGDv76gg8dRvQvqMixPX0xG3tcNt2zQ9FalcxbxfD87KsFMu0mUwkCqgrlDHUXnO3dFIksHjkq2k1Cb9MN7zvYqALFXAwW9B+nWejr85kHJo9Z23lJP1i776bZOqcUjkJlw8BwMFtBhtRSbE8PBnK1wI9nXaa53Qc2G9U0WYD+Tc5u1F9gcUJHpaO8N110usKgM6MUogWagkEFuQOmvnUQavR0WAqHbbnEY374G26YAcJ5/aK+1D87Zwf4/827/8EyG24YhQutI5YUyv904tPJ/PfjU7NvWfQGlV4Kb9qV1OSHjBwVLYT0RqbCzqI1LfX09XT/DuFH/z1EqzY+oRqebdFqNz1Sd5KeqAbiPtMZbfup+GbEsOzzlBbfSZDsXsFd583NgX9j/MOtfXyGkHdyCgjFEtfoOmeR2XyktPNDNDyEvDd+ZEhXiRt4too7VhHESHdGo4fMuUW+HjgCM8CoP42SuIpZJ/fhtFECTJpjF8eQeO5dOe13wuU6iX9gjL4t0=,iv:atIGDgLqT9fDW2oNMeNY6Y4cJsLLWHE7reo/RKVLOh8=,tag:UVUyDTx+aqsjqznZ+mvPdg==,type:str]
+                status: ENC[AES256_GCM,data:hwgMEcBA69j7biA=,iv:JxI68Bs7L1iFUZM3U8zxfEWu1U0M+xKz0kapnqbGqxw=,tag:9kJqFJFaJ8McD0aL5uvy7Q==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:3c4vb0cqxuYrxv/bVaf+GnNWvdYuGG5CoPB4XUMuyTg=,iv:uEFm3hwLTaVRLk6kn1opR/QEyaB6yJYkxtS7VWxYyHI=,tag:dY1X3m6On1dLl3B+6ZvifA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:R0kSWys=,iv:/8nJcdEezpoCkdasr8E9ZL6au/eFQCiRnU/Ar5rFC1w=,tag:cuDH3lPZmfbFq10d38Lv5Q==,type:str]
+                description: ENC[AES256_GCM,data:x8bOmRq68bpEXJUr/LtVkEIAnyvwcAvcVrltHOrJfjhct1JtyXe9s8cYN7MyKcIHK43pPb7MPPMQQWQ9waSlurjIfxbobt7Zm2yjCxVsgXraepYCqQqgIg77qfarZq4FLN2N2Hot2oGkm4t92yMQ2aQ8GX44xcZfvdV4GqQ8vOLLXto2qEB+O+K86pmGKu6H6U9lujXN0sJE5JFAD1Etq7Afoniv9KVHu+fqW3aHnUP1V/Dx3hyo8NrRO1F3X9PunsMmhuxJ9Ntf5p4RRrkksUtXcEjTs5Muio+l8epeKHvCmYp513RGVxlkrvYKmtDm2bHLyQVywdvMABJgqg==,iv:wIwJBtlSqGDWbmDMhR6+NNTHj8vOy0ihVY72CMwdkeY=,tag:1c9QJsmXl49SwKDV4hbHAg==,type:str]
+                status: ENC[AES256_GCM,data:WHaYktanwlb3xTc=,iv:SJooek97xMh2qTWaANJjEZOxWDvd7zGqdLE0P8mHOys=,tag:i1eyNN/waI9qw7W00Fb9bw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:/3R4TP+IDr3t4/fpxFxqpQYPRDMlExugCw/E,iv:mEjGD86O/bqNN6U5kfoh+dsfQKdYXmNCbtX6ELVurjg=,tag:Kyqq/oGgZtWszf+TnxlnnQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:igkBSEM=,iv:AY7Q8JD0dkOaVPx2EEP+FZtOMc04CYzc2IJ9j0M9bWo=,tag:2uY54x3v53h09ClywLhRmA==,type:str]
+                description: ENC[AES256_GCM,data:Eruz8L/H3b9sDOafIxpt6vVCQkxbTf9uLtEHXHFglKVmUxEuUHeIyf0cZJmNEJUNh4gRa9FPDfhBTCuTCw/5/q01j5NDVYMYjgAE7WbvZuLc9MRY5a04ieAQK5DBe8gkizptsXacCBbg8Gh0BxyxJAcXykX9Pro1Vt4kkreur49Ep4whEgsZ5KXgYio0HHB6FRkIzefTMER9TCRvf/3v9Ya89tdP57DLyJWnzilgSEra8B+yW7CyUFzS7ozyrY06bO4tz4Wmd1D3SlA/QJhzQCyuxYsZzV7cBI0JPpzlJvRhg1kq/1q899u3O4po6wCvaTwwDnKXLBmMhJjsBGACcW9x0Ac5lWFCdOjezB3JaCQBLvucTfksmu9/ijz7SRmdFig6EVA1ncCKYYBasWsWeyPN,iv:E7C3+3x7mGz5b2xUQ9NAFvUdhF3sJPjKOeNBy39kpR0=,tag:TUlERlKmJ9+ZdsHtp3LFqQ==,type:str]
+                status: ENC[AES256_GCM,data:lDZ4PFD9uNRCzLQ=,iv:dp/fJnx+pudQKBgwFXEoIB7jpUKA23qx0mO850Lmq5o=,tag:pMyNv57U02VjK6NJV4gKpQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:jBDPpWzbWBn41QzDdIj1FZ6gQlNBypAekw==,iv:Ycn0TWkhP5IVuwiVSDWbAnYN8DXaWPo/YXrbq38C31I=,tag:pOVrtTT3ogoNCRdoQco3jQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:cWqJ91o=,iv:uyGbByXm6qV3cMfnRMzYwopXkLIwJobW8//VPnvdgjA=,tag:LO/qr9FavSe3OKjEpLR0kA==,type:str]
+                description: ENC[AES256_GCM,data:RP2IP1iPUjAJdiwtVcuIcs9l3TTiFtxCfopKvOJDVRWY56HapAyYjlq1ao//jtasSt0hUKqirbP8A8cyqzsyLe9pkR88zClcDuXJlF/0MJzsPdJAP3VnOdyRNByMiv4Kmfrgl+2qFGuzmPers2mgEXQiEFO5drDnGAxvLJis6fxGLTSWtYXQYa464wYTJ+pJnpmaws3wWumw4vbM2QeFvVfSLPlC12HEQYRw/z2s4rFMBS8L3H0JHq7vHDa8oPSUXbyLenYFUjYNOtyy5A99jlfMEWlYU2Rcilbh5qa9QH9mqTdNnM8kHxIHe7tIGewqAwfGHMxjvAtCP3l4AT8v08H+bJ2a3X0/l+fUVDqJK5C3IcQCPWID0yQS9s8kw9qyGVM3siTsEXcr2jjE9aIM4TL1946rjjiJDGNXAMIIrPbGt8xb1O6CQfg0Um1zlZNaEsx4aYF2f6qIj4sE5Mv/ZxF76+nkajbJU1sawqptNM85QjA6GMYwqDofEYYt,iv:Om+YUKBUN35Ke5kJVOfA28pY+d1jhQrLxohAOd8+0xg=,tag:BqktX+HxVCgzpLRpVTHqBA==,type:str]
+                status: ENC[AES256_GCM,data:Xkz7ToT9jJouTiY=,iv:lRIQOzLqiyLs+28g5O8fdN5ZP/eWVTANPHc/BV+7Q9A=,tag:IovnlmCG8MYdDP7M2ge4XA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:FC5JCsuSSST26m8dUWPWS1cyeW9gDwSraoxBlszQit6Gew==,iv:W4c9jlxqQ6C3SkXmgpp9FMnUA5ntozSQIV5S40vihbY=,tag:d3EeyP4JPjTHJqkfg78tmg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:tulhm8w=,iv:8JLo3kWaVG0jaEf0emhBh32q4GaSuUo+KCdh9Alfexk=,tag:kLioiMDjaEzFggeak7MKXg==,type:str]
+                description: ENC[AES256_GCM,data:pdd8rgWueul7u7TzmCP54/xkqqGRy5mFyG7PtcfV0gUiEw/IJi1zBmujz1dPQuKdU4cugLxVEj/v/dqPUJHGb8Xfz7Nj+zJomCMtkmJLAAtHjgFHNDyOWERo/Wf6ln61+Sjd87a/q0md114ovHFypTyexAix/JcRgdZtx2s3q80lOCrfDM0OUsy2zulTt5/8sNunLWnXTGSnIIEUx2V/hGRnJtIGf3Rj+gYPMFor2jyKVa/T6T7TDTOjyr5bdSOMiNO6hE6ogKAgu659X3ETw3GXWfIJxK9/skvS9qea2wssCQVhTWXvT/TfzcY7b3oFdSh4vTORwKk1vSpROlI9beggvMAPAnyvbStL137l2iHTXNFcGaKcyOHJL4h9zw7hTLH3vUDSDHlAYrDoHJCSZE3HPqGTRhLIClcQjszPKg==,iv:Mb9GPwPxqWf6QocUiqEKOOBdu2Vj6k+uC+a7s2a0HlU=,tag:2JHcEKbddzqrfYt+0dKn2w==,type:str]
+                status: ENC[AES256_GCM,data:ruGYJ91affFShL8=,iv:4jtQnciso+jUlRaM/x3XW6eRw+N/UtCuY53MVyDz53s=,tag:uvZNQlrWg9KgRBsdPRI5HQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:nFTI5aSvGSYp9t06udpu80HL1jyZbqLIKq7Neym0,iv:wN8GbBgXi01t1zQVPu+VcKnAgvAf7dKL86eNcMU8WYg=,tag:CfyUMkdMFkUZ8l/AYhk8NQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:qHPM0lE=,iv:mQNEva5Z9LEAYDrkUpfKy3pPadWlULzZEwI8zhOcQlI=,tag:Stdob6Z4pKIED8i0fvplCw==,type:str]
+                description: ENC[AES256_GCM,data:XjfYae2iFOAJnry1uBwU2QFCsv5FVmUgeYlmbRL+FdgHlIpI9J3sdOR845ikTmlT1kdwbMxSKnVEflYohSPS0i7DmcRer4Do02czeRtFd8EAyXBd+EVjRoRngBYiCrSQDzy6yaAdwn8xraj6108WsNAeWhf3iBh2fKKxNV1L3ePe5tz4sp0/0P4MSv2unXmnVlqqTr7nhnu+mqUzcROLBOdiGGQ9Ttk9yGHLH/h8TIWXMQzzWjKshL91ZMLbuyX3f+YaXJx9ptqZDmQr+IrKB9vPyWJHki0pSQS5p6airi4UkOTyEPdbkRqMqBLyyAgvgGJVBsO++tdpKrwEE3uVxtkZQYI7geWoF4hXF8VDQhLwxzGqBio=,iv:CZURPljAoAPZRjdPn7O9hQMk+KLE3xM8H4AtNyAC800=,tag:ZKar+9So6JZlNlSlc49Gng==,type:str]
+                status: ENC[AES256_GCM,data:Prhn4zvr2j4JLSw=,iv:1vODXAmHGiVWBgJEITiBAFAprjLePGkQPphtTYBkBmo=,tag:7DdCn3qItQxhjAVLF4EBqQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:vumH5LNoo56n9TILhiQ3kXkG4/RSRqqhJyFJHtErsQY2,iv:hlorGICqVSWmzTS8LEbHWoZ7m5PJ56OcNNVtWVK+wxU=,tag:k/OqO3/eN+0DA8POHMZO9w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:typpXT0=,iv:g/k578U5yyjtVpA3/ijK+E83+2owystzOj/wwMZSWKc=,tag:+WVjkEdaQStcbZ32y70xlQ==,type:str]
+                description: ENC[AES256_GCM,data:90hZvqj4g5RYboLwLtwWETUDKNEOfOG+oZliZKt+wsKfBHhSf1YPgt68g6ftX54ZNUcLl6bDA1To0vV5Edn6srhq5ed9VaWZJAfy2rE0HdDw4KcNOqISUOCV1PMItqucPlgs168D7Ecz7f7zN48kwrHLbo+jLFlLbAclUTig/m74ojRX5tvNOE2iinNXGltsZFCFejlgdN8qAD99IfGoKnzhwrxkKz9+mazow1Xda6ZCfz9+iEQ4+2jLnXzGXu+8PlBOxHT5lvbXgg71r+MEshJU7RyeiDkzKKbweofZ202lwW0ZnCbDMg/19UHRxX7us1ye/wgUVqCQ8FkI/XFRam1RHUTzmOOXj6K4vBDxcGgZkZB3zrCDIul/iTLclM/Hs9QXXywuo9Tr4jnJ743/DO0+PQl79plrnJ1gcfOlOpCKXf+BJlOjgXFzrQk74ti7yw0+4n9+04s=,iv:5rzueUP62F0trcpWppJm2RNZmhvCVemfNnu1t/s3Cac=,tag:QJG9UaNwRO0YP67yzm0xcw==,type:str]
+                status: ENC[AES256_GCM,data:O6+T0tpHKz5u4Rc=,iv:T70kiQIWysazV0TV4kb5IF+5fdl/eDWzQ0TgeVetnuU=,tag:z/N7uohF2FClFD+xYFdfdg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:FQwGqHr6qcMsWfGA76mRqHCK,iv:MBCGygHheoTVWz8uPDbAqJXixS+gasB4q/FCy5bYwJ0=,tag:z+aJK5qFCapMkqpG2Of23A==,type:str]
+        description: ENC[AES256_GCM,data:Lyr1gOR2sAZguBhvNaIZX+bWwTL/r64UrfaIeK/9axEFI11WXYBaqvTbxxzX97v6UJV1MaOt/tdONDbF0BVOsTuVt7F6kauVeN+Mf5MbdwoWZw3beqt5bIbnxEzQrgQk8I750YMSeqb0W376QvnExqfn9ZkGRBQoQh3PYD6FCcYHZbAdWvj3F2Ph7Oo/S04mUWbp17ngarY7JS863qoOvwaF5jhuMQWBnRXfxLGu+sPSZDmbhVuhxtvzDrio7Xeog1mqvmNHRkXiT8lAZvGXXT9n3sTzDs2nhim11goOA7WO4tuYAEHDEGBUCbI7qLFEvxbb22VqlQsz41XtqtlYcqIwo0qkMWlB5gi0iegR/ZyB9FNzDCk8Hizsz62vy2OCMJ0d,iv:w2d9crFHyDrdZbGA8G9EKKlzTYRZdnrAYSoO36vo1Do=,tag:EnUuuWUCv7bQhnPBfrIQTA==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:UGSGoZk=,iv:EKvpO3Y41GQcx9C2VlkqCATPxDomZZdk61F46z+S+Fw=,tag:kLe6o3epzwtY/nfedX196w==,type:int]
+            probability: ENC[AES256_GCM,data:VXyj+g==,iv:QAMGscZsnA0n8wnbFeJRVAhlDtA+UfWsvnJAMwJ8eDw=,tag:xrc0fYMovt9WXv95PYJWoQ==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:dB8DAMI=,iv:kwm1YzLBg6lDTy8u3hSzy+c6XwgpApL2IFYawlvkeAM=,tag:WxlOWW9yXmzoMre6Z1UGKA==,type:int]
+            probability: ENC[AES256_GCM,data:DQ==,iv:X8QJCuAK5wx0CBl108hA7+Dg8/rAAwTsmRudwMjqAKI=,tag:h3DjrCR7nwM9PmsqDldlAA==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:HD7Wz0oDvLiWR0z23LMcfEQ=,iv:wSyr+agZ0yoDKnGq5VcyLePE4HIPF/SuseH6q38Pgiw=,tag:UqQLYPIW1nkWCybvxWDTAQ==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:gEUxWncmK1i9b7FMaA==,iv:3Bv4MPOvA548JM03XGivtdbRhjo60JVAa55DL13zSPY=,tag:/IFSKOW9g1V4AmW2YbqY9A==,type:str]
+      title: ENC[AES256_GCM,data:QJaXgh1g+5MnJKxG+wtzJXmfld401BfNJXwjgio+paPrtMzDWh6yT1pLE+kJMg+9,iv:eaEASrWRSwCFElTbQHw4xIL6UP8Y5H9TlCDFUy8rdVI=,tag:YfnJTmaVMIiVbRnaFcN9dg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:SVnznlY=,iv:gfyPbmIYLKi4XW2f6moXPsbAAxV+/8ZFGDcilmqVJ2w=,tag:ilU+64LSIq3S7Py1eMUUQw==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:vm0ceiQ=,iv:jMlXTGWWOzSmrd8Gp03AXVaYJhRKRwfoqvnE7Vob6aY=,tag:zbvcBRU3s3uU8tCo0FlR1A==,type:str]
+                description: ENC[AES256_GCM,data:YVvxfg6z/rq6lwXWtxeerZ1urj2F51fVsLyyj9l+S8TETZEZwH6aJ8gT+Poo5SvCECvPXNOHHMUIT70FEO4JE6w4jWcqIiobXeIsDBNpesgysIgBki+c05UHFhg5BzmZVYwVaqOmgfjgC15CohDmNXeEOS4bjGofCy8GnnTkQfXn6uggv/wrLGKyQCBBacSOIPTjCongKdR8SPceZXTwJYf2Imq7AE0Xd7MQL2Y4FkEXrWutTp8VR5Udg3zWyKvz/7GghuwqKAQIzsxTvV0wS8Sj7eA1fh3Emvr9HGqXtrLMzWLSEFfzeLmu,iv:c1kzSnExde3w+YbaNq04q9ubZgJcOuSk0clsxCHIRKw=,tag:JL+EzO8po20odolCNPfshQ==,type:str]
+                status: ENC[AES256_GCM,data:8HwNlwkjs8gpIHQ=,iv:BxiUINdVxYaRcBmWXnydBVmnK0Tmz7joXqohkqBgBuU=,tag:5tLR6FRLeGej1iu2Hyx3mA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:QdCq2jgqR/sHojyTOn64PeRPhjSGQpNUX0b4,iv:9+JtChNX59d5Z43bVtO3mGEybO15V0c8SIUqNpH0GE8=,tag:Bc8FgzW43gyKAm6z+1XFNA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:lrNNCv8=,iv:1ZGFuGfc/yOdGIBAIa66fM9ZnA1jrK/5Saqrs1ZZYLg=,tag:3vIGLpU32JD2QKmwQY2lGw==,type:str]
+                description: ENC[AES256_GCM,data:vNKD+6BtVFP2MpWhJUIKhJZVKexIOdz5lpD56ZIbLhJZmKmyhi6VY81QOnDqW8f1/4/I3zVk8U3OijEPvtsv9vrmexJ6AbNrkxvh6vf4xr/FgvUQ3SRxmSs8V73hBXaxhc7u3E1XvhggjiGwVnvpHeo/6zuC5+BRKu1oTG0/pfi2UGQ17amKOxqhmiWQSvslwT2hpToyQBTpdb4b5ayus1Yq19sGkktxJIcIxjoiZJ0yBn8P2VL5I9JyzvqOA3+RsEJPIJDKfu4lRigLdrHHAXSzcSJXhOBL23gLk5+RB07FDPNfHYKh5jQ5wg3iKY/zklPghkzBw5dDiDvisDqrJMET8Ecc4Ilirr+IwR9QImQ7VPNObvGWcyHRDBhfYHN0NNLCpAZ8Qy19abw0VhLSGmrk58U1xEaj3sCtSPXsEgLP,iv:wgf33EjGEVoeGBVG6b7EKtVumiFyfHvS9/R8jF6i8iw=,tag:HAF4UGBBhDdn2c1+NFICVw==,type:str]
+                status: ENC[AES256_GCM,data:Xn+mIcx9uuDlvL4=,iv:hR/QFrwlo6IMK2QcbDFlK0VOnlm6qpnjyBLuaCSHjC0=,tag:x8nz+jpREsdvHt/1Ol3iYQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:yAnTTx79gJfjuDt3894mdqnhdE2hgWcRZw==,iv:K7DRzdGNdEBGVi3tQVoHf/WbdGiXRTys2LwHY5bcssw=,tag:/Eg4ED69yWynUFhLOYeSyQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:8/0z3QQ=,iv:VNlrwANTOTQH3FYmTj701gtG9N/sVuWBS6evxmdgjm0=,tag:E1BJbOWEasMAdA2mB6kI1w==,type:str]
+                description: ENC[AES256_GCM,data:IRsqGoVdxpwPvkj7rXOVSm3cKfoLDj8inq3+0hjzFeVlbQJ1n/olrJF1s0YPdV48ou6Bb0zamhNIXXZm30rFeyW8Lwj9ro2X2X0zjdJWHGoA/ryABjf3rX4Oj+2lagx5wNFisrHoBjxaN+o8HX7EfQIHYo59lgzJ5gW79vf+uw8WNJ3tCRPHv+NXZWu9TSnNS1N4TTPuAt1F5/a9VWlyKOeMIaBof+V1JN+NYtmEMvLQL5CsHA==,iv:yb8VCM5EADpDq9tY4kIVcHeyAnUjCIgTSVWd8lP840c=,tag:zeRoPvDKErpoQRGYSFaR6Q==,type:str]
+                status: ENC[AES256_GCM,data:IxwZitUQ1CZK7vE=,iv:5lloDTUT0yz6XFKU3HMeloaHvD/ZzvEgEh4sC36w3AM=,tag:yrOsBGI9nWceKZjNMcSkQA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:d7VNy+TtZInI6NlVukEpnCYu4Bi6R+8=,iv:fs1wSLeofMSSiDR5PIJdF1FWRWVDOSLKJheWC0/T4vw=,tag:+cIaNsUDP8a6oN0OtBq1CA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:oCLBRsY=,iv:iut62v8vQxGkVDXR0jx31Qa/ywbML+EgrPKGg6Gx674=,tag:eJLk3lP2osSmwII5wvbfkw==,type:str]
+                description: ENC[AES256_GCM,data:aminJv5psR92AAS8iUddLYVp+ej2c2aC5E9tG22o0lAndMBzXyQp0ZR75fCQ9mTjpfUW8R9A6g2HGfs+603MkQ5BZVuuAOQPGQDuCtHspIcagXqT1MyGgUwCscQIyzM3Ke6jmyBdmbuN0mhXVbslqE3dLI+oAyCISWB+Zjj3kY3us3r8zIuR2AKvGvgAObUZFYpRNmwuvnC+h+ACJEiws2/+edGsXwFZEBTu3MhImrBsUhWW0Diznnv25sHVNgucwnkM2JlFMpg=,iv:ZrqY+0WgpBPgoJcAEdM01Cgt96xRILzJn/io/3p9tew=,tag:h5kFq/DLuIC8dkFc27L+8g==,type:str]
+                status: ENC[AES256_GCM,data:jbJa3xtqFR72b0U=,iv:cFDF/NYhS9uK3yZyFIlR9LXekQmW8aP+tzxCrriXsYM=,tag:DoVfVPJ9J9FuEdSzsBPL9Q==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:UJmNRNaA8c4urD6kMR0lPlCP94y8zQ==,iv:eR+G/bNYDZXbizdMn2Gd3GO+H8/hN0d+l7AmOLVKFTA=,tag:A+iIQiv4wF5WYA4pOJZW7A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:zq05L9M=,iv:dPf2dTRVESCUxrKN0AGSIPuWhOoor2Es4wkjB4afN5o=,tag:rKe5JvD35Fchequ9QWxvVg==,type:str]
+                description: ENC[AES256_GCM,data:3aQWbkR5cfCnlHQkvhDFHNe4NUSjp5oTLt/eASBGrcJwJyCquvU+MtYYk9bmAl7oBcIl25EtgE203/Tn4uKZpHblQ7S9PtWG19INntwys77F4qcbyeGTKLMKr5qeuCASrEL24+Jw5K5TQ6Ouci7lac2FUoNoqIgVYK+0H5wjT70TYG8aeru1nI0yN0+xeLKfyuQ5D7tJbem0Ml1hPt9FMo5G8VevwFNqfnFG69Gy8+emIaCzoiyOiSSSw86KoRU0qWt8g1i34plSMbVNtjiecLnyXh2QJ7+o1gZWfZwXakErAMnrvNWAHTyHWmdsXGijtGX8u2psEZVIYo5+/1J5JlA8BWwZdubCXS6aYmLB/Hf4ZuEN7uYSupTKjRthy/wlUYT7GWjB0Y0h,iv:VLR/ZJ7EMPwNU/dVaD4arNKVRPsC9oI96ynzPAI5xKA=,tag:gC88Ka+PU/XHWGTlEAMAjw==,type:str]
+                status: ENC[AES256_GCM,data:kS+09UgwSD9NIU4=,iv:ss6nBLh4LbLEH7GAyRJDAhKmAkj5WrFWXGmEVlKEEu4=,tag:wU55D95yJLYGLDw2mYELGA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:peqepy3CW68muP2n8zDSqQg4,iv:9jvhQO+bk0PX2MOoo0ZCsnr77OXZX4cHUVyw1m11+bg=,tag:Fic4qe9rcGqzEB7NeXfbcQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:SCjIMfw=,iv:BQWZu3V/S9agd40aQX0GWsuQBzt1nmpOCno1ReNFGDk=,tag:6wbeIbqShVapPWTT/wsoAA==,type:str]
+                description: ENC[AES256_GCM,data:jjlKt68LfRyw4geTPk0UAaJExJE5k74XLcN+WUp+BboGIxte5jZADCwpruZ60hIiXqOSC2G/Rkec4a0brE9omSLDm17ucFfjJGnz7oH93hG1rcF0WlF69V/E6ouJIUAmPUaWCxvQnFmRLsHvVwePUztN9UhLhfrFKHNw1KL3NOVnqaWfCDD+ny9yyHymXdFwaWOu6RMijYZaMml5IDB0naG3JkVcKGZC/vWYbuiCmhqKYxINQLZC8Es1BMrgZFKKiAKTbEXVzJQUyWsNNgd5xpZeZlp63DOG/bW0VLvdasbY2YAHFXpnbeeHHhaVwSYqwjbGEWmPznyQlkx5qte1dyT7PDIADyjsCrQwjJeai3N4UDvrx27upJi8dtrB9uYkHc9su0GFy9RdOE+DlGPH7v2xPEvlYeq1lqthXPG29V0D3xchgV46SnEV3sdVIhVakIDz6ZuQ9IczesTHUEvHg4XCTY0ST3Xf0Er4Gdq+D9NjC08iX2Yqcd0xyGOuyh0q9c3QTcXpF0UnO+wx/u/cb1fW/OO8YAdR34bbYGPKwpxL4MAT4T/UIoNufaoh9C/J91e4dGmFvRDgdHpFpsDKX8d1iwh49r9NINozG1F5Flsj7KUEv8o+z30Wv9Bbyw5UFV9wY5hgnKqAlLfQSw4ejtZyqNwZUKrx2u+mPI+KEDAmm4q63LCn4/5BhC0KHqJYq+g3MDwnufQKHXDvAhaTKEcryxV9RKvdBuJvJMh7ZM3lArFD6/1Wr6t91kseu4PGdkGhE7jW6LlMymwDBzp/6v3U9TgQPcX6VMdK7ir1omCdOCgH9zJMqIhDdDDzSTCzj5Qk42gKjWYrTBasN7FqBX0tq4iUleDwANiYGbGATXJGyJez9/9kLi7gO4GCSQNBFi4gyp7ieL2Wmyjljdt1WKU2C+WsJk5gzvY1HYb82+dGutY=,iv:ZONeMCvV4efoOTHCissIeXXTpFF7e5qe8g38cgGphFU=,tag:0PbugR4WA3WqtJXy3JaWew==,type:str]
+                status: ENC[AES256_GCM,data:W+6+50T41MYTzfc=,iv:jS9cJu9Y3NO2bqe60OFRByo10VdzfneBMZDcRhe8nEM=,tag:ixf+vmPmttB0AF87jGPLyA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:JZ9xdTsNTVJwJKepPtgsIyObrCfr7YbKwFtQ,iv:VMmfSfwMl2lXTU4xss/3Oerrr+n7Hq/BlxSuIXDaisg=,tag:kYEiQm23PLVWI/28YyuBVQ==,type:str]
+        description: ENC[AES256_GCM,data:lHWi+zmSoEUG8xXnih+ksbVF7in97Tu6Bf+IT6mDhKnVhIOfYuKcNoDIl7M6l+pVBOKV/46+Y463h2OI7AhPZISRUpIXaGUdBQxyVoL/Lwigy68k/TAkPRJqaoUGiigGPnkrYh0vhg4VPydmNI8Y2UEE3dQ9mBxWkLD6A6iO7oa74uYFVmzeE75yYVzyrFBAukUiUlUUC/l2yEVIDOtL5XBCM61Xn/3QHLBaH+tjcKOgaxosmc51ZHKsdh+946MU9GJvJU7eUCizGUKhWBjSnqQbafI/9+dE3A==,iv:+ER/ByBI2BrRl9fX7W0StMkiYw+ZE+oydRj+G9R2hk0=,tag:C7si33CKh+6O4rUV4v/nCw==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:UcpVDNIeaA==,iv:kVUwK7KSndT2VZrw2683/3+3Ybk3YSJ83Qbv47bB3ao=,tag:C5UEA0xMMPqGqzG+OmpYpg==,type:int]
+            probability: ENC[AES256_GCM,data:4GRl2g==,iv:SJ4vrCX4Qbq8Me8NjSndLrU+Toe/EEBDGthmUnmWVGE=,tag:3MJDAIa3qzZDntHo9q2QVw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:0PKHZ3ptHA==,iv:FSjQGXlBZl8JbLqXXiW371luVS3CDOzbMshkjrODRvs=,tag:m/bv2Ppgl/1RtJ2NghxF0Q==,type:int]
+            probability: ENC[AES256_GCM,data:5A==,iv:dTd5aQvcRX9Tkky8fIA5iFYMTcx4jv9Adb8/QOGdIZ0=,tag:zTgKtGeMMsUR1gL8og63qw==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:zMBZ6lO0CxlPHlLISBZespw=,iv:VttganA6K8EKHQd2WYl9eaYxbNpsJgZWVO77yEoBvOE=,tag:usRG2JnuC0v71XQmzN624w==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:iwenQNyv9s+3u3MjyA==,iv:r4+m0YL8AjpnVAL4LHrqQqB7qPY6ReIja0JjdY+X1q8=,tag:ydYnFFQnlwUEbIYXC4dFWA==,type:str]
+      title: ENC[AES256_GCM,data:SdP9wQ6mKMUnRs4+ifG2eozhCZOtMCQQdzVO3HVjcSOpHIt8VVwvjzql,iv:Ruxs6/QQDxgbZbf7m+qHpl6qOECUvFLVDGXVcfcYM/E=,tag:HdFgh2WsC1Tm3zJFHCa43A==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:QKrk7Vs=,iv:YjDRm3DkWSA8bApELb3Kt7EdrtFhH3MTygs1TuOOMag=,tag:5mkY4pg4rHLfLcpugojMLw==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:eGrpyfA=,iv:ailJmdj/5eQ864gjFvhbeGS23j3oECwx+XZ6QzJLNWE=,tag:gs44BrIwvEhw3DZNxffD/A==,type:str]
+                description: ENC[AES256_GCM,data:jAJ9duHLj89tA6JMZ2uA0+xHP6/HNh4n4BSTWSiLiPIVfA3+63ya+Ryz5vSMM/8A0uyhH+fKV81p3XtcUZFH2mWf8QQsoOB5sSDsVppWWf+Q9vwQDIzcTDpXrbeBRZfxxgYm+48k1iRRducjD6xsgp+DEoD+2dX+L5hL43ooOLNqARPU9syx1fTZ1fux6HgldX4+INVPVCedVmrsqInNqZdGVPbLlosdTNEAEC86tGa4T2knnTK5a9wsWELF1C3ojQ2FudUYAEhb6AEcrUostTUm7AXH7Nf5Fr5af0EM9ogrIMK0f1AOV9W6gYkRhH7TJiTh/fcJww8U/a/OM2fITQ==,iv:3VNsBFHf8zpbErKkLPSyrTtjpRar8tfkj58JY2jdT7k=,tag:t0umB+bxBgYoVDJY0z+g/Q==,type:str]
+                status: ENC[AES256_GCM,data:w1KidaXcJcgXT3w=,iv:xVc4yp0pqa+WhGvnO7IX3yti8bK+e0k26JOPu8zoGLg=,tag:rndvb1TfeCdHZFSEuHth0g==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:ZZi7RBqxZdziiNXW,iv:3l48/mNXNSxN+VlsaQOFSa9+K5iwqhZ2D+uck2PVCYA=,tag:JUFPqjh7VUlk6Ym2mr5gdg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:4tRiJ4o=,iv:ywvYPgykUPAQB5J+0tSIXv5IOlHZDJEHouCcqQtCT+s=,tag:I8z5Jh0pjg+FwPtx8wimIw==,type:str]
+                description: ENC[AES256_GCM,data:Uk44L2dR7lE1fHoSN3hZicXMmQTaWXSl4hstIFdmoJQi1yAiWmEJC4YrzFojOdoYBGQF/U3qolwoG4jkbCMld5B1NfA9yWZk1Le+0a6QJvNOD12ZZ3f/J6RmjzPK/0bCvA6Lp6HtAVOSyQCs1cg7KpMn1r4ToNhJjyKHNTdMqm6kAGsxX9+D0fS4rbzPdIqISeRQZcSlGtwVa+eZKoFPbyCgyhCqt/ncpclatcNa3Epj5C31X2BsTleQm5/dfATKu/csv4IZXGr6GFakJgyj4fZwiGBeV9XPixqtpWUXtypAzMauWUesWy3eILw97jKkKD7ZSDQDuKMw+1ypVE4BNijZG4RTziMX5YVe9lCqOJAaURusp2jIfgRlr+vhTaL1lOpIlCGmXYRg3eivOafR/AEQ5w==,iv:IS0oA6f1yDLgb42+0JSHrOr2AYabaFDhuEdj4Uqmz6M=,tag:XRCVss7v4l0xrOxEptMuMw==,type:str]
+                status: ENC[AES256_GCM,data:/Iask6VyCLJ0HDw=,iv:YzgcBRPIQD1C/N+nAwPamJj3lbkNFkULhuBHCRvrFvg=,tag:ksPlUN4B2ymD6DkaduAx1A==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:AJ5vI6sRDGHSEC09jjfRtIf4DxMJQgmWXQK0XNk=,iv:ZrCy1SiY3HPUZRPGqZPN94lJGyOlClM9hDR+KMJVpAs=,tag:2LAUocWF4ZjcMQT1NTnvkg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:YRsAkt0=,iv:fyhhIAyS7rgoytdBcHlAdnAL3aXrX0oF4ej+/UXANHI=,tag:5o1HsNbqr0Gk/UvO0N1zDQ==,type:str]
+                description: ENC[AES256_GCM,data:5HNTzU6jn1OQ/eBC1gaKzDNZQuPiOxSAABbSk0dKa9B8sTIqHI0Fsk5lx8YPqQj11NchD5HiYztmiN2+vUpKaoBR9WHZvfFEtWymg4n+oWdVx99+TrllII9l4FVnFGoaMystizrhaTdq1zDK/nCLJ5Ddw4MFQkCqTBi3e6c+ak2/uJJHnFAKPTlfz5lQT14jrVTmwiavAd/xCRI9O/qrTI+yQvk75FEb9ys9nBB9uO8zODaSz2M10fhLVFuQ20u6/1KQ1FOFpqgSoZtFUWoLnOswl+YP5j5pgx8NWdl7Z9cT0KjPFAUtPPG8jeg1R/YVs3iTLx2esnG6EaFRl8e0xbXz0nkok6GyzpXiuTeIkRLn5/o3,iv:GK3XAd5HIMNVm3oCXk8NSJ746CjEsVN00s7MarXHEgc=,tag:kniaR9+wSEdc/INJksc+Vw==,type:str]
+                status: ENC[AES256_GCM,data:Bc2qVdAvemrVx34=,iv:mnVo/HyCDPodMM93GDFLkHha1X0fnWxfCsOl2gMNnpw=,tag:PMWu9botpHTW9BBV/NiF4Q==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:jMwVItb71gHgdkH2VTZoXQ==,iv:JjNLHUQ8d3EZLZVCQwnIF4JBrx3B26O/bAAj5MG+Jhg=,tag:8IM27TKCbL+QvgfOovLKUA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:DudbXQU=,iv:uQx4G8UTo9lvBuHjxP8p4my9brZjipFJZScN6jOJBgk=,tag:yNBy5j8uHbdqC+U3McCLsA==,type:str]
+                description: ENC[AES256_GCM,data:+3g9bJ7t/qorx7kHPM1xjKLkHi/ZxSY6XvkcRrN9D5SGRGhx2kEKMNmcGEetlb32L7iEqi3jDGePS7Ie0mccnh9/hmz3MurOw5v/Mli2pb79xGtiKJRj5BtWlNRl33i/UgqLVX1iInQTMmy8Q8JHFyH3XwS91gCUAOwi0XeS6VTBggrjQcBkjj0yWYyKVYwCWqR2b4Ci1c7fM/VedQNqstt849f1+YI7tTijZdORmT3+VujYEgFOTCa6zhA4U7TAgiwmJR45LeKOsUQmPcwku9E2sdw2qduJaWKZe+T3enEUtVGpZarPk5C5yPB26uVsiX3ovUZYDN7KWOqjfaFbRp8RgUx5IC1u3BswniLJ2OQ/jbKHt1RBi7YS6KxqKJCuQ7rqPxwG,iv:vVgQbFoZbLOh+dbghVacQ2IMjWzeYqLPtfb7XAVI/Ck=,tag:PLh1caCXk6a95pORjHeVGA==,type:str]
+                status: ENC[AES256_GCM,data:XivJA0ebAtMD5Vc=,iv:DP/wVhu1jxoqQchB8ozYqmnNeE4dzPbYep/fi8Kz63I=,tag:gd6ZWIsfYdZIZDWdAdxEaQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:ldMuhb3q9fBxhcrzTAIAWdNIZXCBDIY=,iv:BY/Eb9flQ9O1uere+WSFl7oOmeJAEOmNjbQfe2jbPv4=,tag:mhKFNFK700oCYoDXxsSXXA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:8glE04o=,iv:sfwgHWf4HuIPQ7Arqs2wh/nCDC+6EpVzSPNYr+Gizxk=,tag:5X/eMWs5xrmATU/1O2GUWw==,type:str]
+                description: ENC[AES256_GCM,data:fBHA7pYPAxr6Hah2xS4Yk8dpegKdClF/8tH06a3sBjEZRkLVQ4GkEnCeBJQk+tlXVMPZV5DhcSB6yr3D8+Zd3io/yiJ5vm0WPA5G7T0pqIIzh2fqbqo/JOMS4/ojYP42rke8qU5ytJizgwzvC5Fu92o9mXsVM9inO3tekhaP3fVoQ+MJGifi4UIKxHs1lYPJuyJMoqWzXjC/x9Dw7Z5SoPTPnl7S1Nox0JYV/YdNphS+JJkqCqjRxXHVw7I5LCpCnPgZZoJ/1sQMnjvZ4F5poLbZiQ+M/00PFGGPnLkGXyQKY+cGbEBRd0RV/p0BTx72AIrqb176BQ2+jzcn33+Tzd6Ok3xeXAe5DwF79z3UJYQC2qh6INqKHiUqohMt316IqZVrzZQzXp5JR/wfwZrsTUaWfVZTjQES9T5Mp9jZuXPlwMvSASpAlH1l41CoKcIW97/xVYroF/scwyhN5Hy0dRWv9w==,iv:sURdldQtaiU3l4SKfdy2A6lsDL+nw2B1mMNh5/lqlko=,tag:k33auaDcH0I7aiDeds3/ZQ==,type:str]
+                status: ENC[AES256_GCM,data:f9sE+EF7AjvZH5k=,iv:C7WxR3SECrO7QkGRieMi2LGP6zjg+Ng8PNY6xEVEL4Q=,tag:k8rqrZFce9+2fTaGDIWThw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:4LqBxME3qmuv8dGBF8FVEd23r49so+b8LO4=,iv:N/i/KY2xRRJXWzCz4QDnX92ozSdjQePP6b/8cG99Qok=,tag:4UtSJD877JKl6LLtoR4bLw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:8lWWdlA=,iv:sPNzIqkDVGV385/KKxiIN7cM4rXbPFYgMf0Ba8UB2BY=,tag:BFXb57m6QDz7awxPb9OF3Q==,type:str]
+                description: ENC[AES256_GCM,data:YW+xb1wOs1xuft/9UUUQY6NKkhbJagzH4aOUcWLguumwswGtsoEJRFbZz52m/oi9UrmLR37qR51g24zxa6zMqfn4HtwH/huMSNs5+cJlrDHB51z8vPt9iJfCzzCiJxqAPm58q9EVoFrjjT2oXkTqWaNza/roTmfwAuIhUQOSpHsqrqtEeWeFORXjefI/S88H3ZF/FJ7euQnbfk3IafyBHVNKymmNbzyjJktVB2zEeYwd83A1jAEb7x7wufPmBMhJYhe8SaIeKvXa8l/ECPNlRz45Qs0ADfxOC1rgbJT7qdVQ4U2uqpUSS9av94+uJuXGvThqPHt8ZqHsE74vb296xmZKOi3RJzmqLxbiDUhunW3+1J/Kbojjye8QMHekSRHCZ2MAy0YO7WiET/Sa1tjyziMewufrc7547LoVmUfitqQm+GZ0cpaU/1TMlcoLxlV+ADlSNU1jcmATuF42nMSF4sgARKLzSeljOsECYsiFY2EkTYM86m7WVKmLdRVgzL38IBfYxwUjA8Apt0M4gJCy7R1B1qcCWQD8rffHVaRYHqM/pmzVVh24n0Itu6Sz+g==,iv:oZdZsMdKP2qN0Fp10ks4dhsVOri25nfgYU4p6xWqiY8=,tag:45bcvWJO8AkQWneHKeAQcg==,type:str]
+                status: ENC[AES256_GCM,data:aMuFXLnYj4s3FEI=,iv:xpPp+mkZZswv4qeDE67+dd4Er9q1wCW72VlmVS5kOZI=,tag:sClUUMDFR60J6wMJlob5PA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:NFkGrznj/H2BA7ooAOD4IRMbPUagvLE=,iv:f2vXDIz4dmUZAWGQmGG1hWJDE5IAmY8A8sGBsz/Wih0=,tag:+myoxIRNU/DoGy0G2irl0w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:tYMektU=,iv:VBn7kRLoD+DFdebxNo0YXX6vOQkP6YpYFizXrrmKHDI=,tag:9DyqRSSccHg6ttZIz58yGA==,type:str]
+                description: ENC[AES256_GCM,data:FS1y01jm7Cma5Nw5HJI7u71bqENaYDf2/fgh57G71qnFCkPqtbdI5B3mHmGV+/65SPzEGbuN4RZGvr9iKHlaHq55DKYFCZ+1yFQB9eZfzFkMmfBrojG63i/ShBuDAF6jZQH8+ffdsv4Po+JZXn2ZExnC1E81DuLLcxhHYw/o1pjrwPGHlWbDucnIL+Wax7kIwad0GOqgCU4JiRazWHtgbqKLYrXpNTj8HLWPRmq0sWcYYR1Tr2n0SEUvYkz1xDMC8Sk2yFdPfAEENSZC/HvPtn3xgL4yie8Ucg6f3VRQZvlmPzZsMPUnnrNeRPKnBFWDq8y7+lS4wslR3DdrQxD2vMEAXg/AmqO9cQlni5C4MuhmDjLDQuzR7Cr5xbWygKEpMpFMiBRdyaVKQf5oc6LMlHnpnhFYKZppuQlp6oLojcAjEQVeP97YQ3vQxaBySlMMTTnfOTM9/+GEEUzlK2nR2FfMZyHE1U9vRbbyQHV+JcVZGF4oFnQbqpHGR1bRjC9AA3Jy+PTyYoRx3bNeUraRXkXGEpE=,iv:UpH8rrS7uL5mxZCai75rik3N6SM3JgzvHYww6zWt5f8=,tag:jPxTR3SI3GvpxQREeDSDWw==,type:str]
+                status: ENC[AES256_GCM,data:eW6EkpA6K8h3jSU=,iv:2OzSTPedBfRjS8rpkgf3GsyJyl9umknPgVEX5DNy7wQ=,tag:y7dk8fusyFpaSMh3j5V/Bg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:zsuNIGecIUiOJW9gyCW2hDDpusU=,iv:n81EZ5bMd7Mcu0R2xjSJxdnchXIy99b+X3HIzd+NkhA=,tag:tj/Ha/eezuPsB/6LAuuANg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:kMvCDEk=,iv:LAvF+HnM2hnBYd+b/PqV2nhbQ2N5V23otn3w02Kezw4=,tag:CpdQF7hKUd+ilyXk3dLNPg==,type:str]
+                description: ENC[AES256_GCM,data:4utB70oSCU3lRO8DL4baOPHIDv4/zOuBC7DW08Tps5TzwTiffUbZ7gENXC7GXw+RxA6W7hMKFKGjJQl2vXV4g8vc2U2v4YsrqLmuNMRHnpzDpZvKtpIm2s/Pd8Lu5CRitQMGPfOhHWPhPmSftDPItqyJ43Rk9gc3MzZA7V8BypOcaTDqjKlUavqLScO6U6jGihHyJ6/HIY+o9kPiusiLE22TOi+LfkyOadgY1xFxXBRN3JpkSTIg/KETyX9sdrX1mO9LDiEcMhhEJyoEi1nT8gyXBWIDDcM+928aesrG3qtImIXnmZ4Xl3jmEYNta6+rEZUnrD8zrcAqt1aNztJNyyy5tp6/RmCLocJK1OnnylI4RbBPeQ1H6cM4kY4isI+66keZmjXcszRzXAD5f523J0KRyA1NRYUn1W2V6Q==,iv:vbpEneCZbFM5j+TB+Ic6I7K4oSX1TNa8lx9QWto4F8k=,tag:jD3e5UPDAtcBW01XZzp8yQ==,type:str]
+                status: ENC[AES256_GCM,data:Qd7IaI00pxLanO0=,iv:bYz9sSQcGpCpFP5w0jcJFfs/xYAEsarDNflbYflL2cc=,tag:+LD1zLdNZi9xSwDPQEHYbA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:d+CM0iRN5C2oAOPENOF4v4qBEPKq5di4ya852Q==,iv:hyc6UGT0t9DO+4qrwT2nqmRJG8hFdejMmo4+AryPYEw=,tag:1SQKu+kYeftxQI4UFEFeYg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Wl+KjGA=,iv:wQXizzisBznrf4qFSv1E6lAazYOWOaN8SqZIlrCSTu8=,tag:TcMIgPqRwphyNS7yC2cb0w==,type:str]
+                description: ENC[AES256_GCM,data:jmRgcJFs2KkgIHt5MZDIje3EuWtU97BOXZ9Kr4Udqv/XWpeIHFXUfqWOh1Qo2TlnFqHyHVOHIryT0zmm39u0OjpQv8s7d8xfuK1Wc2YoRV9rEo/zuiBnvx02WcrokdrPiYr7Zawl2UaX8SdPhL7jw+lJbK8PIa5fjdeg2rXo6sZJH7y2+CfedmVXL17rSbPZaSXHIJW6AwDMwvhtpYL/qShq0PSjB0naXdAXYN9UWX5O8toGS02r0w==,iv:PIwjOLuxgc32BApvAN9IRIqpm2HQHca9pV0u4gdHU4U=,tag:3PhkpXkmXJ8N7bWGvkrS4Q==,type:str]
+                status: ENC[AES256_GCM,data:qDP7d88Ukwajhfg=,iv:fDa0wqgZkM4875Nj6G/3Z4YDnxvHcozDPDhbi+c3lDc=,tag:9OUTPZxlc2EWwae4HpekPw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:M33X/Cmi0A4KCzRdaEBPHBfJQSh+5xRuvAxAZqwDWA==,iv:XUBHGK8tueM20vSCpowtydVbqxUMjXpDb4OkaoqCx3s=,tag:8TP+D1yEWairDJqWoVzm5w==,type:str]
+        description: ENC[AES256_GCM,data:TQZyYVLwWJi0Nr/HorMAqOvfqdPd6+O7Yc8fUpvC6L2v8M1/VGRO03JwrzOaD9XIG8BnetBMzkYhpiKymxlkAVZJ6XttgWVtgNIUyXfnRrc0w+R9BIkxYSa1a7hi6C4zZ+m3nUqnvRh8vqRQ6xMiw81KC4eZBA2n/ZYnGUNJPVSp2sElkF4o6TQZtQ8blCZI/9D6Mpbb4i7dnI4ynVG2cTEEy9VYZwPCyEER3/VvfsskiDfZWR2h+r3fmC0ahT45T8OKBNfapVOoUBdpfaRcXL5QJ1sp6ybibukPAzstdNlRkdRegCfWmpsMWqSxK52kpyfa9vnh34Y0+9xuQLOzVPJHg/4boESiRODbcklfNc3TJi32fnIEx24IEFJuQltXyHwPXkL+UjAx4TIZ5NYrAb3chDqcKuL+PwauHGxPkS4p79Dto4n3WAsFlfyyH9lmHco0P+AT4/Dg2UW+kuytkCcm,iv:12tTOexoYLTdjOVPiQf3om0zvUJIwLJrDAVV+4lX4nU=,tag:H3lvdBk9S5FYb+yQZPtOog==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:Xatx5cMtAA==,iv:cPKhTa6aBqaO4HW2+/47C5YkSiSw9H5zdoY5ktqv0Fk=,tag:8Oi+IuvBsuOkJtpTHuVzAA==,type:int]
+            probability: ENC[AES256_GCM,data:yYzvxw==,iv:1o/sfmF3RsWkTOEKqHlnxk95F5+R90l/ha8cOl1hBDE=,tag:IU4jw+iBTUz21f2bs47DYQ==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:qOL5iGsU1A==,iv:fO63G1nRElDRGdSbFZjA/RaZBTgWxE/j/Bmi2MYLmEA=,tag:iPOQ4a6MqXCeHHsjIFwfGQ==,type:int]
+            probability: ENC[AES256_GCM,data:82I1,iv:TMk04vYbfu05fhizKpQDI9ZturwO6PqSb1CHNLfshY0=,tag:szfVE9kspUyiv/vxEOs4ug==,type:float]
+        threatActors:
+            - ENC[AES256_GCM,data:QE8zvKeTn1oIbKiHCJ2FvCA=,iv:prrUYFnYAQ52tLow5mw75DcA1SvK2JuMV7+5wWsFtX4=,tag:Gt1iaL+qfL4bj11v3VRJ3w==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:cmsz+7INGS8QSYQnJw==,iv:FvXiSSzglf0skkR9togV8UtcL6709l33xcUZdioaZF0=,tag:gC+YaWRpQLQqpNy6Zzgs7Q==,type:str]
+      title: ENC[AES256_GCM,data:G7ZavgBWprXt9k4Z1wFsXYNqtNw0YdlbkVItkIaQprDm7Kq+eFFa45lSVJk2YYs=,iv:dH6WFXw/oh2XPCU9za5HDiUeHlWO0EHMZX2pq/XOtFE=,tag:Pbe+bWWRfd0iLkczrPUeAg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:eu2QAa8=,iv:Fuv1tEuwoLta1lg6yBrmb/oSghmFacjrIUi/EpqNXV0=,tag:HeadMAxgy/+gd2AxzX/Zrg==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:YYUkzgE=,iv:9HzSaBhbb9aWaWNZfYr/9nDNZ9NuP+DIPRGvChf02BA=,tag:2kGdmwlLG8YLeUjgA4YzXw==,type:str]
+                description: ENC[AES256_GCM,data:DN4EGxlWfAkRdDEnzhpJRVLPIrkCaa8UDdU2x8U6HOVf3X1oyPQV85Q/PmSN4dCDWsE21an7QJlLr9Svb4Nlx/6iY7QesbWK5bHNGaKRyhM30elwMV7BmaDOHk/wSGtAQlwqIXmTcDVPZRN2WqyqOJXAEnzLCw+5NreyXG1J1vor3DQ1k/WSYCTlZKD60vfmYrcOWvsM0aZCB7Ynly/qwhATjNtgL5C8ao5qAwoohFHBLWpY1e6qarW+MEhHc2VYOA4qpuu7bT0fkcWT0Uqu4eoOyzct+UVE,iv:QVRB9GyYj0T1ibm6FgOiOYoVlXoqdWUiORz0IxOYcq0=,tag:pI7Wg5ljeYNHTNW3/oxBBw==,type:str]
+                status: ENC[AES256_GCM,data:c324reNPqQJf5Ew=,iv:XGjkmGaDl7SqsEYzCzR8MEGbifbnR0+NH83yrdPJrKw=,tag:jYHhQtU7YOj/sQXELbbzmg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:XQEaI393vLx0Gk0=,iv:yM7I7WVTjbSX0DgAts93pmoxcx72Is/xl8/PmcpyCCk=,tag:nxAas4an97Z+N1WnF2Gy6A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:UKuxS7Y=,iv:8XXo9MOnGI+Lb7E2RjJANjJjCCKyoM3/FZbHgucai+0=,tag:8rKYp0cWBSe2DGTmmH+mrg==,type:str]
+                description: ENC[AES256_GCM,data:IQW6fP6ClaHRmS7NS1keJgU6U3fC0VM2mcJ1Gr7tRUUMxDZaa/lovl8L8SDNkLJFM8YHCV4aRe98FvJElDw6luLF4h420MKvcAfnJwae502hyllRQ7tKP3WdTe+6jI0na1N0V31+UsM5jxWBfImV+KrXeEwG+tCTdfDXAwGJBksYsu714EUe8WmoB6nJ/PjEZOTb7wiAGpMbCKnGadwJhSDtX/ARFKeW7d27QYyAbCamlyp2cPMBl30HXRXxw9ztUGYiN0RJD8CY9Eog6KjNw9iP7qjcqFkbUkP3s8lteTK7O1oekpXdyeygkUsY73hbm4LGUd6GS//T1JO1Gs7vwmQ7wDNsWFHyImFtSHQU8pJwYSPZbx4X5piUNmJ4SU7gpg==,iv:OP9PiQtmihZPNq5+mIvkBcAGNay3L+C9afvVuGX0i3o=,tag:8TL6Zb+E/2A39TVTdD7WAg==,type:str]
+                status: ENC[AES256_GCM,data:A2zgqyYs4GadvpQ=,iv:d37vwoK3OgsuFnsGhdh0R09OaYRmqHv4LfJFuJCWCHI=,tag:Cyh9Tpk41RBD4aWkXh23lg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:svtI7Y4Kunt2zedYvaszHzEvGtEs0ZK8azM=,iv:wmlamgUG6hlh+9FKocK0txLrgc7qV38VMBbAwPSo/78=,tag:vCrD3tvhYTsT1+kjeBTNbg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:DA67r7w=,iv:99+2StXa2613wyO1YgfuZEeuRgfSPIjhlFFaCbHd0TI=,tag:26FfnoBr23AKS4cQiWT1CQ==,type:str]
+                description: ENC[AES256_GCM,data:FOROaVSqfyvtg3cF0HGZhEjPteJy+BnXQVPUqDliWUx7Kgf7MtXgw7AibFIJ8jTvC/8hhPIxNHoAOnLwtM0aSQ+ksvaDdMuh4K4+zZsvzxZggtMS18b92iYyw2/LyvxotPHO0MpUmMdUWSqGDsFyt7rYnXslRRAV6hEYWoYZnGWs3Q1c9bxmVj0nFWAIhVBhjiRn8/blvozBSpBx3MqXVhHpTKWvWqkEQkYvJE3h8BnxocUIPRwbj8OyHqfmFzgA04/ym8ocbxP61I5pRRLR2m6Q8zAg2rPjM9ihqNkUvYOaawhfCZy4ozlxw7lp4vp2r6cwPoiCL1x1P3Y1xJj2c2pDGIobUHW/g5ggW0bRW+f2cfBw0qthfmp5jINwL5/FlIXYW70b1W8T0a8JzKEfkr5KXGgOn8sQN0KKiZyiXZEklvOB2haHfnz90FH3rZFJ7OQynVuij+kSZIBdETrcQCtdP06Fr9Pq4jIoPuDsb3haQz+W+z3oWIY=,iv:tTysfJ4qpOhX6uzgqKLmbzcf/iqlKHu0lV6v6h96sUk=,tag:7MJS7pZrfgf3I9YAYDYEAA==,type:str]
+                status: ENC[AES256_GCM,data:8Whgep31hgY0zeA=,iv:vxjRedQ9aK446WjHhuXgRuZhqdyZvtKo9LdLkD+c8jQ=,tag:XaaGCuY8fouGUpuCsMJmbA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:e+Ldu0RSEw7jrlj2upWANO2crgFgq4mld31W,iv:oKLT4jFJaoTqsRIuvt5osJ+AAjAlBAjgwI0axu0sHgc=,tag:ekXSWxWa4Ma7wyuqv2Dm+A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:OV6YP0U=,iv:Nv+lKPCoG/DvTwPwelpCGFuDETESi2Vj47lRwngzLRw=,tag:vWz/JKp9uo/Dye+JI9I16w==,type:str]
+                description: ENC[AES256_GCM,data:Sri8AwX8b8erYNVV6vApsSJumZKC8A0KN17eOUUnIhYUCG+yjoVM1mHZWzer3N65CYUlnhwOlKN1w/HAHsADxsrKyvAUzLhYgGSRXiT1jmluliMP1D5bZmQ+CIovl8RJpfR+PoW+Rm8DixhnTgW503Wd1Da9tpACdvY2Jik1D/nKS+0yt2o7LC5D66HWE1Ysy/aJ7pJQ/qR76eH8knZbRRJHa+fo6hWQZ8rOWkLpjbNs+uqqFn8PXIxtF5S5QLe3mjt1XDupjRS3smlDWYrvtz/AG3DmSDT2zkO78z/Bufv8qKWvbDXMYqQN2qCkh2JdDEgBhBO87FTayfOhBeNdZXl+yBERwY1+BrNFpNhHR/2rpaG6SaK1LDu+4e3ilDoNPI0x64LMwbEGFaOCXp9/ExgPmo7hBBujjwH7NcN/sLy7GOMwS2c=,iv:szIvsRssMrs11D8w81VS7GIlUxt5iKnmqPK/jod4Az0=,tag:3vOEo5DeSueU2Pqalyc4GQ==,type:str]
+                status: ENC[AES256_GCM,data:Juyy+j+AnMy5hLs=,iv:CQsNON6G20v1RxlHAss6b1kBvzgEJ0LbwoT0Z2GNylU=,tag:aSgi+akPLDO3jef5/Ta3sw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:2dGxSuASLvayCBjemcAoaaV/z3C6FEA=,iv:z8TFwW9Isq1okwUsSyzJL6R+i27KOiRDIZl7ztNupaE=,tag:6Wo1c3LZgytF5Womge9J0Q==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:o57+IbM=,iv:/I84Vfvf6OWoM9imknUPzOKUIPQjZlUWjg1VA0yy5TI=,tag:TBkwbKd+g0on6b0GQpht2A==,type:str]
+                description: ENC[AES256_GCM,data:fqbeCwKr1lq3RgZMrRVdL/MOa40eepK8B2BZ/cw5fm8TQEuM5EoPj2aR6amY5n7nshMSWcmXkutvSdWJwL7XvagRmgPuBCg1uidraf9kxFdgKr/xiP/jwY8i+U1yOFY9cgHQSnQI5U8X1GAMUmFgMjvbAuSfnv8Q1AdjpSH9xutdnYl9KTrZOiuDPirKZRjZ16XT8RryCjVspLZsrFZ1o89g0v/oGSeD3CfSxKdviNXbGEIvlnG+u+l3IyAQOR7AYq2qeCOOoyxSWyNsMpLPSJOK6JZ4n32mwV4QeBHEd2zMuVxJGfyz63ibxK3DHQ4HLMJLZ8fSu1d/haPkeo9rqjQaudmoCU72mEysf5HF1A==,iv:efqCXT1ofvT3vkWKdYXhcDWmO2WJmyxwfRxFllzZ228=,tag:8xYtnRr09ShSiNDeMLdogQ==,type:str]
+                status: ENC[AES256_GCM,data:ppIt0Akba0PmGaA=,iv:eNep9ONKTOeVC0Z91W1Z/9H0d/nm0R5mFl3cvsveFu0=,tag:oXjCex1AQ7W8wzIfiZwu5g==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:N/eZh17x5lSQ+99OfSIhms74eRbeQAX7nVA/Aw==,iv:QnNNp4OwIs1QOckqy4gZpnfEd8isgUteCWsOWyDiPr0=,tag:4gFNxrgSvwSZcNhFANN50A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:3+EqNq4=,iv:bgPDmW9XmABTDqZK8r1CCRag6vpvH19gdKyEY4mlyyI=,tag:dUz4RBkexBcAV6yAcAjPHA==,type:str]
+                description: ENC[AES256_GCM,data:Ax1kZhcz96GTxTBbDTH840rcaVlYq+Os1cFlwn2fHPDSNo7xQYiCFB9ECec88hdVUjCkX67YdDAIguO78oMW3FELoPnGn8TSgLkfwgVL4kLrWmGB7qRwdjPx9zZkVhRGQMIVNXTnfTirgyyxfHqIJqxYftfLY5+2SSCkafQnnc+2OaP6c/JgB6jSueuIxQ9sV9X67F+o1j4TiIw/mOJ58LiCAlVZy/78bPqk1CVWR2Elm0X8YOAVyImrBuq94wJoRjLF4kYUN1kdgwC/+4OpfeH/KUHjz976mlUAQJPFkgPakcj6R2bsPyD5HfmLlvDGZ0QWoqbGplYjKzm1dpa07BtmjZcSJOCvm3L/MrVBems2x5vL4DX6vhc6h342eKEZ7BxwGk2b2uxioIUj32v/RkjuXZKyJgpdcIjiYF+KrPuEerMkgmTMlS3HfB/wc2u4KIwI/j0r/DRh4iymX7bdLGJrdD1W7xuTuecH296cww/0X2IHIpUHpiUB7mVzkAAH09mgmgM/k0g+0bkyhDxDEa8uaXHwL0cHliONJjYkGCRRs1UT548oDVhl5JrjMiXViUGdQbZfLYTu6AFGJuxDgrhnoBd7iUKcAkBpQkGxv1aSfQlfsYDCd568bnOOO45slP0XRg2ty5NsQwxg1k5mXQPFPRK2C+iKFMeeY996AEBYqgbc1FL6NLEBkuGyDe0RrAZWHWQY4ZhOoaOYlr2aLpP6BH26GAP4Gu2aVgNIaqZ2iumPgMT2FIuvzEViOrTNImmXK0fMb/O5ayi5xKAB2OZRWXflZYBHAWXDZIC4xBwvv98JMbh7aWN+bFfIeZWbyfCtzHzIjPVTvwf3qR/KnyaFmb5Nxru7IQTnYMp/GXZqC7els1zydEwHq+JaivMOGNww8qAOe1NtB9WYs5NsFJOk4OTof7HniWhVql14vMJcI4s=,iv:InMt5WdwlNn1/JkRunBYoS6eCa7AkSsRf8WwcTqT5hM=,tag:Bmu19cHlFpwGXO3tmD5Z/g==,type:str]
+                status: ENC[AES256_GCM,data:bf8NCDqP5WuBeA8=,iv:ElrFBfKxrOXhxuRDdpbIEvCZ5mSiczaQlIpgUsB81M8=,tag:h30EMKRkqYg1909TO9z+Yw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:xjg308jhqjgco+VWxk5TGUWnmLxPGNn/9ZyG,iv:QubQXKkW1iuTTwThXXfRAJnHINs5BbQ4hXQsOCCIc0E=,tag:dsJDB0lBePm4wmRG2Qd1/w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Ge8kG+4=,iv:Zg2riy2R+OExXZsjZh7WxpuT5SNZBzqB3SpP4Ag36HM=,tag:3S82P/U9usywGvbC531fMg==,type:str]
+                description: ENC[AES256_GCM,data:CsrEcGpVeK/JnCKpzbmlRyxVucQLrv4+1T47+ZxZL95l5uaJMlztYwA/nbWNs3NtRa6cQaHEv9HMibLczyzsL4/heX4oom4hcz136M0P0Pj/X8k9pTV4YUS6uuQm2XMC8cc0ObGs595crsPiUZwIF5NPItID48WD91sA/gO6tNO/Em+PmeiKCre0nWY8rhsQKMzw8pBgZjA+xcjMMQrbzpVDzaLNxbP5TOSuQ2QNupXKYOH9FfmDWPlxZQIj1aO3UJnkQQJaHnJQ5JA5a2aFjcrNJ3KvGsfKCSSwYjzfWxhEAAbCnlu6L2Szq93r1dfUbMmsV9Q=,iv:5pR0InVSg2LyosvqlVHV7iQlveoHDtOO+6O9w+inaMM=,tag:8UQU4kp8hpiQP/ph9GNGqw==,type:str]
+                status: ENC[AES256_GCM,data:5jsxUpbzOzHuIpw=,iv:9ySRW8smf8wan3jqFF3/wd94gSqqMrmRtssT0COHtvs=,tag:rkdiLPRhjho1skvcNE1wsA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:XpD6VX56ED5yNgprun1iRJ5NNTsluA==,iv:2FcjneC0VhbOigrdpABMW3kzS3621k+aqi40wyUJDjo=,tag:F9dicCH2fxDvZ7u7rCaRLg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:IVRVtDM=,iv:bRrAM33MivsGJ6sY6aFPBdgmQsFsivwBmKhCiOjVwEU=,tag:3ljzvim+PaOMYBH9xqjHeQ==,type:str]
+                description: ENC[AES256_GCM,data:KgAHk/Y10SpYyGYpndQvAcpkys3W4L30X0Na+jLizS9vMvr7tLk2lhbhUen0j5yVh6NUEfeaKkKDtmNMzJh7L8Bnj4gxhfkfM9n89z2JkzVCFfdlKriIztjySHoVG6SUs+ZAjYvzc2ylUrJpBnJEyoNUvf/G+IdD5O9Y9pMg1R3ubOO6aTnw+Ow1QJgeCgeJe21ssWjwbYsb0tatlcGH1/2fOHQUsnxXj4wvkmQXB4v2b8D8ZNnHD4lgSKlWpVmTZDxBs4gFFSxmg+EzU2CVJ7d/ghGjgSBWxYJajRqDdz4tNQvLRZGL2MOShM/n/8/xfFMSwMP4UE+mciFEZP5kl0/07ZAkSCxMSh6hjR3ahOo/Va8kfGDmbx9Hf66IHinnl9M38P+ah3qARPbAvuxn08VSkN/8qJmUUO1sRG6Di9Hpjvojp7N/t+kcZIIU4yNIjchElUkZbFUusHMlNtcequX83jQ22kyN9v+AWFQE5eWmdUu9Um1GgtrG/m7UsawO,iv:rKxVxYajQJc8PQYnzOX7Y2OX1nhkcTVoPt2kb8km2kQ=,tag:8R0pWn5zSHqnMka8ri9kFQ==,type:str]
+                status: ENC[AES256_GCM,data:Nc0OXrcduGv0DiU=,iv:Koy0KqVwMczsu2L3AN3fg0jfJ1WjN+62cBp02vnxNzc=,tag:LNxV7aqcUyRbv+ZSafCiQw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:oa7WAmZENDP1LyhUjQcWxfQyFITLRA==,iv:0k5MoZ2eIp4z7qSgBF3+G8qlIXCgY8vbJIgIPdweMw4=,tag:tthkDbQW1U6/VBPANUvxgA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:6DynYCg=,iv:wQ0LEdf6hWBMevacPoPTD2wsB9AuLCASFA6k5HvXVUk=,tag:u64n7tK/MkpGMK90VXN8pg==,type:str]
+                description: ENC[AES256_GCM,data:TwkzKi/hgdxM9V+N+Z1OKYiGEbqGepeI+ZB+rzpHPgKbigVUDgHZxevETiURSn/xE/pGskxisOdKIBxfp+9WwfbPi3FZevvmOQFGE4sRUeyqTA2tymrv7zuFWb1KCX2pmWTZW5K41r6B0wZLoOZpFKjtMldRFArGJXrU4OEUq71cdweHnrUHh+729ii5+rnWG3rpIo/XVPmYI0RCPGR6IlfWoxpzJ9TCtZptr4E59Fc0IF/Fvyw/Mk63Pvz7MQSlq/kA8mhw7dTVuERAtA7Pu4+WFsSQ8HgH1GwaRwfDrhm91m6UKLPOQ+2jQDCMg6ujIrlTR6cP3kBezb0jP8LPTPXDMHxN9yJLULpUInsmvoFb8SDRw4YzZA4Sxd26G7P3n5TXLkkx0+1k7NswbvVoIpfmPVGGWNr9VkcuEKeGJkB5Sm0jbwKJoYXHx6E0ZLJh3OsWtGleUOQmYMsQh0B2rdib9BQ=,iv:rjNvHpB4pyDiIgw1mXkyUApMhIxz6GZtWTEOQVDjq5w=,tag:xYM+vJY51SzWYVi1cWBFVw==,type:str]
+                status: ENC[AES256_GCM,data:TpAXZGftmTgMad8=,iv:TOF00R/2mopnlHIiOPL0V2D2nJ1GIIEwv/eesQE3vK0=,tag:7VQbYimy/4TUvymqg7tLUQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:X8ZSkxCcu3axyGEuyI7H2No=,iv:GY2ocxqFYyWOHhHKtrF1qj4Z6YlXlspS622YCfyzGnI=,tag:rSZwQaQ6iBrKU/9DPrvxeQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:0nI+rdA=,iv:Vk2ezoANXmGoUK8tReqDSZpfzDS4l5Vel++/kdsA+0Y=,tag:Pw9LUo8NzOE3fXMAHth+VQ==,type:str]
+                description: ENC[AES256_GCM,data:uP2yVBp53QncSZeBWT3OlI0teyXDR3x/3bHgH1velV0ffASDmPNzRQ6TrPffqi5r/GideMOTQ7+aHc2hnLpoPmtSY7Sth9yEwU7Wbls7RVUQFbYknjFHgyFrpVGA2bdZGPbuEipXH/8CPHlb4KAvdODdaPi3FInoS8/WEniP23n2ThaRqMDJR5dR6EuUYYZqkzmEa2uhv6NQMJ0zWSRhsG6zyfkmGCZ20OmjqyWAA848pe/ZmKL7Do1KnLZdz//PXXcnzpncpl3aqsOMD8xktQ==,iv:Sfbj0OHAG4LmU8kNfhjhKJAZ7mxUfk+SL36BLTlvQUk=,tag:YUP4IIh17g1+enna2NGVDA==,type:str]
+                status: ENC[AES256_GCM,data:MsVxR9mm+3BNn74=,iv:rAsB1d1V1YvCjL+ug2SqRlXEGMlFS9kMJ/bSfBszCnI=,tag:S1zLcCgoqy3nugXK6y16sw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:fdVGwMPZupTPJVnMifESdvGrqKpWwx4=,iv:KeK36qFk/D90CMYBdMNED5QLxnPZVVo0R0A/qPtCO4M=,tag:NJYZM+i4Knxz2Gf1G5q0mA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:2ZdJKhM=,iv:AIejVHshkJnf9Wxk6lWY+9WumUdvByc6NX/Ju8n3/IQ=,tag:C/cPnwH/kBadSO/RHUBdXQ==,type:str]
+                description: ENC[AES256_GCM,data:+DMm1tbheOivl7wmootqAxOGX6wc1A8l0o7mysG6kP7emjUdZ4r9Eim2jw9J4GxAOcnnWJD9c27+ilsTIgj0E2y5VzoTLQq68IzYzsWDIimRtY/xROA1pAf37UNFnnblJ6otyqlitczW1y6HEVuYvERjhItOJd9pVhMQs3ToSoEQpLrdZBE3WF/yXL45jGJeAYVx6CzQ/JXUB+P0X0v80PIEnRLG06TcY4tCm5e/IUj017OUDFMFPJW/Vcgz9CISM1qy8qsL6Ph1avXBDX/mG8RVU8EgRdH63Goh4ydLecoPhIB0nfxFr8Bv5QEh8y/NGj593gtHDVnocbWqxuBrQY1Mm7xogehA4Sigqc+15+M=,iv:WWjAZOy4HhFkpPosTs0sz08x12TwvVgga5MgCX23ULg=,tag:wfHVCrAGDGxcveIx43FIMA==,type:str]
+                status: ENC[AES256_GCM,data:XCOvL8uaoXw16C0=,iv:kgUvN2GT5IBmHfJP+BcRrloQh1szZMLYdF3CWzbeNr8=,tag:9gHqvrVlqlZD0lXzZ3ukvw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:OnXf2jQonb7AOWMz+FMZiP0MtrhW,iv:UTaB7gBMAYnd5rxPRURfXTh6e4MOGlj9YLb8qqb1U/4=,tag:P3Otbh3329P65v+s5TxMDQ==,type:str]
+        description: ENC[AES256_GCM,data:x+k8H02v3D9kbeNQGa8bw/mXJ2Ua3wtGjLcJmYaYYdIKWoMN3JVjXqX6L4qIwmihNhZ9nX5HbnUGfqmMg0J856H6jXFVW/52vTDHSTeCNahdq1Vebpulog9cCHuF7CNvnI6qQA0xtI3muaJpYV+eXV9kdL3I/GbG2zPpAlBg83O+0cfl7xaG2UhfoRLbzrC9KqtD4+B6yQHQNcltVtuUWrdm+m0phBQPPyNwfDLadyZ0WkgOO3qgAUHfRh3rLSLmURHYgxQbfvzx1eUO15ZaxBkCwpiyqZaLlDagh28HOE7Gt4uYU//1ePgofo3kwGOabW76hAIKQtcxzssXneFi4wQ+Ge2lRdIEcPk9axobsQQ3tjZi+g5LzjVe5kjOmtCrl23GWh513wKR2C/PdRlilX/eXn8xCPRYAMySkM7WIkzzHMwsrYq38nLXzx2XekHyEoQaFYvZEZsY2hBUyrdKqmbL+rSFkCAk+7q+XOB5iqf6m4b8IEWnyko=,iv:bAFybXE0l6ZaNB0DGsVtdPyaIyqOCSEwiQlsTTNdt80=,tag:aU6BagSSz+UNj1QYWUH8IQ==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:9xgc62A=,iv:xGFH8rB4jHjQ50qCZaGIc5rc9/XKhtKLpquZR6dp6UQ=,tag:0fcMBgr9Or5D4qO2VwLvJw==,type:int]
+            probability: ENC[AES256_GCM,data:KoM6Dg==,iv:oM2j6CljJxSoaeR0gW/G+ELSLZ/BYsOWmQha4s0QHrU=,tag:RKKyyMJ6r7FQTuGj4/3trg==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:+aSQtiI=,iv:4hiB2Aa4OCMgaD4K4pjPV1jVgzvqsQS5QxOW8MEE9Lk=,tag:UL10U7SOS7YSvolQl+44xQ==,type:int]
+            probability: ENC[AES256_GCM,data:wm4=,iv:jvhfAzdEoTCheTruqeEDr0ac6saD/fDMDywxmz5lNzc=,tag:RlmBylCGBuKBjFg7PQveHg==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:34rHyZh6wMxfQw==,iv:94xBEehl9B066koiEDcvYhFTgrggWCL4yMzgAPIVzMs=,tag:OxUo7DHLRQo6pCQ8iweoeg==,type:str]
+            - ENC[AES256_GCM,data:Rw1RuJcVEuhCAOh+pUcfXgcxxDHRjA==,iv:zKObtxdHBi5nK27XWCnNRxx+o8FYAZreb9VHwBp0KN4=,tag:6BnXo+yZFuvo6wGzGT/OrA==,type:str]
+            - ENC[AES256_GCM,data:+qpfWeRP8q5r2eJqoCe9,iv:UZOEQGGV1PF5iIV+4LPuVM1F3HOFVKyvQKNB8DwL8jQ=,tag:0YG1hF5qrT8wJNeD5E2wSw==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:e0m2l7QQKVgjlqcDyQ==,iv:+KHTwCqXrKbqqeTqIcRM+oZun42HH8g52vD8Zy/5yts=,tag:kdkEPQk37exdZFcX8KfICQ==,type:str]
+            - ENC[AES256_GCM,data:kmuk6lTwUCzKb+Gqp6iW,iv:lXNuKQYkTB5/ahhB2vRXKG4FPOPwtenb4ST5VRLBtqM=,tag:6GCm4s02pOk4L5DnqxFU7Q==,type:str]
+      title: ENC[AES256_GCM,data:IGqs3OsG+n2DnJZb2J9oI6ef3OejPq2Tp7W7+fYqaqFpGaOhpY6/EUMUWALwSXRWSZOyM/SCkaoiRg6XECZ9/5AN3gS05/hUGkp2zC7Xgg==,iv:+j2ehKAF+BI5J5LEy27WqmntziJY4nV3tBgZkrwtDc8=,tag:LLlvo5fdGmSe8MFiWqkEow==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:PqMKVVM=,iv:QKiFjvH3UQ+SgA+i2FK6xdgGjbrmnJAin0Tm/OuE7AA=,tag:9+pizlbQETog/Ci7MlE67Q==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:YbdovkQ=,iv:0i8gXrHm9yutTU8R8vs0qdKHnEJdcua+H+n3Vfi9Pfw=,tag:AhkCMz+bMrHDYZjzMWhw4g==,type:str]
+                description: ENC[AES256_GCM,data:/ShXrzap3jSV6TuMjDLN7xzS0mIxc12TATIxyB8VLZRvKKNry83vi8PWyr3aqwsp0UjZ0e5UY3iDJl1fK9sfIa6HapaOTq6BPS7tyMLcN9jGCAfYIQcKEcoN8Go7Uuj/xaI0MAwN2H93DR56MXEKNF+zT85okImTjKSIH2XiE3Wc4maNir7IzM4j9SHOUDaRYcwi4wC/e4chP1NKb36+XkTwW6s8PesLxOk6urfGkWAUw1TRtyB9/yq800aFIcm2vZU3SBTFyvmlAE0YsheiacM++9Qbx3HvDEsNwlR5lw==,iv:KsrFntjN910Ae/cgCJCuedp8cHNiVTUhq71nyezgUjU=,tag:Qb3LVy1YkiYNbPu/FMMqJA==,type:str]
+                status: ENC[AES256_GCM,data:uGRG6afysQAvWvs=,iv:5NdwhjTRaY8V7WVsU1LHM6IAbmBPKbJUIHfs6gDC6k0=,tag:Wht8x+wgz0C193dgAbGaXw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:e0fcyMaHD7Wasv7Ixf9SZ2aB6BvRsckYknQ=,iv:Wv92yoZr3DDv23jBJaoaeb/z713gz+YMFkc094t1d4I=,tag:psNBbgxHGnTcXras+tMWMQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:tCxTGE4=,iv:bllMb/E+OxXaoRPqA5bj7APlBvqvqHOD9yE5p+fqgsE=,tag:DZxq877nd2k1u0apHIAh1Q==,type:str]
+                description: ENC[AES256_GCM,data:XivwAtquiqCMtAa8SogKmDgHcYsGKhTOyIVIBl8kKv3EK+qR8k9q08sGouIqKkQRKZh2pj2rBoxq2dwIhicVpaZ46sHQRxFBDz6T6D59U6ed5GB1XwmUe7BpZtfrRWSlHDFVMnFKKayg/2OwqrF5OxXXp8Wv+lDN5O36xNjP660S3tCKwvwa1BHbF5gzkA1MzJulT18/3JuPcv/yM5lrd+i42XScGdC+uDO68hR2C+dtMTqq5wDAYDtS1NG5WtJRfH33O1MhJymXJNIn6tp/NpS7/eCtUJyIqlrb2KnR4/QsCkiey+PIBKcGVba0/LSMBPEDOh8vZ+DlOKBAYuINpxoc8QhjGfMCvAMRPBJzvfMt924wrhR8FLYneh+zhAwQX2hzqQdX9RFaDCDwZ5LpMLpnaZpGIeMBFhE8E3Ul3GjVfpZYLbw+aiCkG+qAZfxXCzg5F2hcymXE4MrGLUoIUc4ZiiPse7YeoLUTDONQDXbeVA==,iv:1KsHtAnxLwNg1ail+xncua7xV2l+euZ0xca/3tEFRyU=,tag:/EL1vJdfNsIasOKBqS56yA==,type:str]
+                status: ENC[AES256_GCM,data:ucR55tG1PJcD42A=,iv:KfYdCu1RMOZ086vkdLwXK8wNtmMRNsPSnb5erorI0CI=,tag:k2y0HF7f93htKAUwMp7V7w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:+sW12mJs+BtX7yvAvfMT+Xc/tGM6Y4IFJu0=,iv:Pe4UzHVsLXR7IvwRvyUjwNFcN3X5nE+ovP0nz/sY5hc=,tag:RKFuuHSMx9CCCmD7QA+GNw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Ru7rDQo=,iv:HeWcFiAnRECTustr4Rf19CvQpg8BX1x7TU6LCmt4sPU=,tag:HKX1q6TmncScfi0ajoDPDQ==,type:str]
+                description: ENC[AES256_GCM,data:lS7vCTExCUqJqnghnjzqgZ6OdaFZLACBWXn2maR7TXCHWpxqjNnI8CpYBxHW+oGh20S+POaopXUD+Y/IAZWP7oQmvLWJtMHmJQEomCOI2wNS5h9E+gUOckrkVGeDe/jpSMHijNLo7Ah+1GYzVnhrov34jjsRNk7WbfsHcszEkM0tasSDmjAuLOcXkxK3xfPNswCwqO3yDjnqzanPQUUix9wu6E9meKqAmRpLsZPgFot53pYGdHJOdj+fU2uClbrZJrLlo2Zpag5aq/8Omhl6hsULpRENDoNE3mEaQqIPen39jaeYju5nyf48hCW5XhR1mFtbVwdJjx7VvGrvoVIi6heyYZ/stakRcJTNrrCl2g1OfGuWxatjInYlCwSVuBeShqOY/7wHWtw+NjrbDbr3TO5o9kqlMm2xoAVNB9hFp0vZq3jxPbOvjbZR0yza7Zg0i6fN67N5H2y1LUoG36dZ9fyOXAbcGIrNfYScr4FI4HUIyz3BIPGbYycdnFz/ZmJEQZCO9/iDAcDUIuNTEJ7PitCGSMnou8KdJFtCykD3RiEoXFxn4iuCo94ihtGzYsgjD+b0zaJROjH7aqD8D3wvbNFxAZvzPemfZOL9rC2TpGVtsEIs84qPsJjbjY8+3oEk6F0mhr8=,iv:HMjv5iAUC8sNS0wVdCZIen/r3CxDdosaaFUzijGEAyo=,tag:zZF6Oo6y8+HCXlmi06zDhg==,type:str]
+                status: ENC[AES256_GCM,data:uJWKzZ2kC111Xto=,iv:1VRFJfLOitN4F5fw2GKfr8gvf+cUvpw6hheaUt5H3bA=,tag:QrQkdKMFfdNCFTRvvXE7fQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:goKl/1Gd802HxUBaUY1wpjRh4g==,iv:jobWiX4lqvYxpfg84CobMt4LUknQA6bIr7MVfiAN+DA=,tag:njnn0ZjLclibnXNQ2u4XUA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:a/s0QPg=,iv:Jt819zPi8+m+WlCiMiXpXhK7ee/uzQ1nvdt1bB6kI6A=,tag:M0eS1VWBsk2tCIN35B17Yg==,type:str]
+                description: ENC[AES256_GCM,data:Ut0ndXDA3UH8mqB7BnoLSmiH+7OOWjzrWRFSpk/DLqmAqZgXd7H0kK3orMJUzS8qQKMLuwUuMLjUPs4/oZx+FScSzrLBLhMNXuS71PAeC7pur3WYBls7HNpSeVJumz9Orr+vcOtrAU1qFWguMYSaTCJXWFyhLeQbGkyGcsmgQeZ/ED6jAzBmKvQ+Ch78nAeQ3UqhTt5p3ReobY6ZmzMWM8DSS6JK7Dgi2fkGl6WS8iWzW8RuxyhTuxkguPyqgpBMWSaVQy/Jt2FaGZGlBLQeOGhX+/2rNslD3uK1LyfgPsZLLlAuiyuH1A39VNqDhKplsy9Vw+6Wi3gcILs/0UQ/ptzQXTpFMVYCwgoPP0FhVIX1y3ncmXSsj6zY59/msbGSC56t9zcuWrKnVgHXW3mmBpv/PciLPt3r6CUf7NiKt0DitK/9rQP5JN0b4Dbm4vH087sdUl9ehRbW/xNurhTeTa4wLLIColExekcab7p0kGA8QVelOAJ88X4pqWU5ikisEHIp3+vOD7ze/mzNAhnfKBRdxqQTHxY/5fOKtN7C3lDpJrCoe/1okRdQSs7rEMFgzGIsqaHIadXoWMX/fxI9PUlMMd7YCbmsvqQ=,iv:IuiChGmEkjyX4VrmePCL8Or2TW0qhSzv+iuu3g0B+yI=,tag:VCTR2upr+e38cJXXl3KFlw==,type:str]
+                status: ENC[AES256_GCM,data:n/vqg2YGYLzOl0w=,iv:/w1nw9ctuQ0f1Extznc+qM/63akPx0WMwazqZLB8TTU=,tag:yeaO+eT+3q5QUDoWrGZGTg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:JSv+Lsdd9PN4pj586vsO9lc8nqhPCJMx,iv:sHTmEK76UkER5FjzxKh0OlfvlXG991RbNjtFbW8gLnI=,tag:dsVdGuXb0Q9LHFsqLrnOvA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:NU9Z7ww=,iv:MODYSawkRbAgh1HRYGoHSvCICdsz2J2RTUkZIDAkH4g=,tag:eT6HVCeecNjIZWgOS26gWA==,type:str]
+                description: ENC[AES256_GCM,data:gpBftWeyxXZQ11m7ydyLaaw2X0mZ8tio7q/QYI+6851jI7RjgV3LryveP842QZQNGuTUJPps/Nzn1VagPIuKW/6xqltnfz++bhIw5JwJr8hNUVyU0lNJXh+dC3BKqVKFyHf1jvpL5peJi9AicFCM4+TpKFxp6Ma4ITX8yLfvo1bofKMDuXFxBTv3C7bYMmM7T4C9P3YrIvdCty7bUIDgX+zlOCmbUJCQrH8Z/XKFZXVLcwfcKxc=,iv:64vYq6FjiILiVZw/blZHF2N9nGZ8AwvaeHR567cnRAg=,tag:1Y01m/6cIrCHA2JEy8t31w==,type:str]
+                status: ENC[AES256_GCM,data:2V2uUuyez5jMl0Q=,iv:KdAMG4LlWCiavvx0PjEMJ+cKwNx5o2NO5pNKKPkh7+w=,tag:C2d16mMj4lxcgOdMnSETvQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:J1klx0y9EmZZJdcUZAQWXPHrx8o=,iv:RrYjztMNBCRo5olvvXTH+5iexUIngyKa36f0WKePxQc=,tag:5gGOao4m9HPOo55y8vZWfQ==,type:str]
+        description: ENC[AES256_GCM,data:XY3ADHuLmrGiYYNymC+nDk2AqhntEGR37Sm2m+Rl5DrfgEUj/yT7ZBLLEzUyqpCsd4M4YhsJ89mM708a8rKJj+44iFLVIx4BZqUpYBUgrD/9t7tmRXc+Ky3Lnhsmdlpcaxxs41TEo+TEhgQVjlLGFDAEm6uqttemiAZr428A6OiKlDmccb5UHJKLgHJf3CpK3TADGOoxoV5htbYLA8sq6C5Lw/xbJcQS4qzfiUIat7SAssgFFhC+XXl6rqcLi40wGdg6QCKAVUjHNbbiFzV9lQHMau7e9aTCn25I1KtGEba/BosxKXW4YK9rk4cDVzXiTK2Lw9NB9fE+kH5MPj3RdogghEJ8pgXKPQ86keWl3ZORIT2P1HVGaKGCp56p+bSnDHxSByDeICHViAqA8GsTWPfXrGvU0lDz3GSO0Bckgsq97uadZBCEqPfTU9Q=,iv:JAkT11RMYmSwdphNUhlt88qMEogO404sRRDuBL3oxbU=,tag:YRQbwFIEn5Fxzt78alLXfw==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:qvYdWCFFWw==,iv:vHVSXSwmiK9KjunKuK0ko5VyiWtMLpAFun/zomf8FQI=,tag:KjDVY2VrpI34HoR3Q/+iyg==,type:int]
+            probability: ENC[AES256_GCM,data:JFj3ww==,iv:rsmEQEWxs842SX1SmYx8xOSDonTEvUYg4Kjf6ah8g+8=,tag:SMr3WqhRT7Qc++OOycoVug==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:+CLUZpRjfFM=,iv:hBnc+A9yjrWaa/ZLhaR5OOvheqDG5F8S0qTxlvJAevs=,tag:79t5XsCp4yvf2aIqriSYcQ==,type:int]
+            probability: ENC[AES256_GCM,data:5A==,iv:iy1K6Cp0k6fNz+zTbuEeDLsvfoJ1zenrofP92fL9oQA=,tag:xaDQvfMNJJI9z0w+gcrDZA==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:eeghkHlysw==,iv:eBwWyxi/qLOBePkYqWiBIMUuC6k0POB8HOu2xDSEsnc=,tag:zZSDsCQwFwmaNCxARzS85Q==,type:str]
+            - ENC[AES256_GCM,data:ueA44xTxsUFOUdfJOBBLH0c=,iv:FTqGRfQMAkuAlFiM4traLccIwfnqpCCspzTmHxneDm8=,tag:XhLmI7mOHbdWYmV2+qSUng==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:YDMvapcoexJMneq1xJ67EKvKwQ==,iv:s37lIVkLDMHngYbOCHI8GRvdAju1DjXzpmecs029j40=,tag:wDuUjCCcXo54zufEPQok5Q==,type:str]
+            - ENC[AES256_GCM,data:NU47ZjeKNXEO7mQkSStl,iv:VL4cqWlxvJdHpnHnhKnlw0Idla+X7hDEhCje8fvAJAM=,tag:IE7BJ1FcwqiA5Bl7LZ9QRw==,type:str]
+      title: ENC[AES256_GCM,data:6cLjgB4j8+kCFbGKiDq1hVUOrI6qRKDhRaQ+hmR6IpadFtGT/iJIfotX/WsXGmaV7IgV070cwVuwin/rStKP5cDxE5eEW8akaTCB8Vkyow==,iv:BKoxsnwvVxfGqm6aCZVtLTWrRtPuwEptQnsVJ3Y6BQ4=,tag:VXTq81uZHGnmAMIqTJcMzw==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:27XVZ3s=,iv:fSj5lDISy670FB2bPZmuN8+XKiGD/o8/sGzanKA8QEI=,tag:LG6/h9S8YWIoulI16b8V4Q==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:/92Xyio=,iv:jNRXDtHEq7Aprjmj8nKcSMaCr6cT2b8CEqRdiHAN2mc=,tag:kiU+j6+g1PerugNXs+Kk2Q==,type:str]
+                description: ENC[AES256_GCM,data:dc0L8TXJWnM/w7TKmySDi78/NZiYv8n9dJrrxyzS5rJKuvPJII6pPooqWYT7eIAjvV0b4paqGxu4Xc+O8lEnQra8aAAq0L/bvPeSwgRKT+S4dVElVB5gkB1+PGuGElgdmvZ8F7BPxEbDlXEVD27+qJ1Flu+mm8Apl6hyPR+OMLQOafJqXvumRsRwnGqJ/YcHE8n8gySRB5psdj8ZeoAjLWGDrm/epBkXlfSlOjBbidgPtpZu5x9Jrrah2jYkoAbchsRmLhkrbfn5jXzFE3bUei8Z5sf8BEOM1RAHWb61byjN5Bmc+Xt2lojMQ+EdAjCzKzG0H3XQiM/P1jmf60oNMHXWswq6XsbP07Fnb5ZXV3qYiR4eMkbSaOHebXqpYaxXihgxwOfUOXyLK6nTZeIpulZqR99NnL+EuhisUCfBJNWn2ghmx2q8NWDPqqCDtZcAUbnA5xl8J0ouLlnHUeiEAVML9kw88JOVpaIsefyYjDUaSVzRhUK7gmPhv1uEJMuok32iob/Cow32gWvSFhEFjam4yhQWJELa++hzjMWSG1Yay9xgDDFiNZiehCyclBPq5eJREzhVbquTaw7TPVt4yvutRruSGQ7BME07vAw9bbs83g0Iv6d6OkW+oHg8GmXbH4JraGWlvTqggAVTa1plhunYmJXAAZZ119qXnALZDbLh27oPZIXq4txhJgTKMMv5V+Q31jxn5SCT8Yo8LfRS6I25HxSqnfc0guTXSOTkfDWcxZsz0+BDH0SfXwbKHC+2p1I1WoN3WlIzJiOoKnP4AXNmFUGHlE9W6VYMnDkSq0tL/PcQEEuCCguqWU/Yq5mbLywzjSvUH+9gEkXdB8K19W0MoFTg/Ze7iJEim+8VdHZUio/bp7RdKmdpqjgwzmaUfv27BpJL2ORL3I55Shemj4ZpgV3sf5Tvi7ei8eSPJSSSqmeAxkJH4JkHza6AGgK1fTYEFiE1V4yURN0rEt/3e+ZlIcAazbDI0awJxLUDndSYVPf1yYxI2S/s4Iyd0T4kTkWYl77O3DMscSC+5wQMWXbvZ24gRgJs6CRLOwlzP/qQZv44rDL/RzsIatFL55zZg/KdcIRwcIRN0rIbxNJ5Dwj5tPL0fyNt1l+8sx6GyG1ktoLLIwUIGID57qVAKKVWYp0QcnxaT2qCfdTIvdNEk8dUzJWE0ffkmnHKfjgCSVU=,iv:meS/EfQJcGPncUDcyXf9BZY+thsmRSr0LMYinkHYo6M=,tag:czS+HFyl59GMSlydIZ1sCA==,type:str]
+                status: ENC[AES256_GCM,data:ux8kiS6n5I1weDs=,iv:hqAlCX5Z/ckIa41mUJacuQbazI+ig+jcRUWqCMl3VcM=,tag:Xv8zobfUsHsTuAa8CDpR/w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:cPB7AkSLvcxbL4SziXCdSWYuAEttmw+P,iv:kT2juFhcfHOrXrs64SXzvoxlqSaquGRScq0kCcXHMw8=,tag:vxqBKNexbI8E9QeogmTkaA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:CDgMnuY=,iv:vWexlYwz8osw4Xx5haKRgzN/BXc7VURcVnnqFguvrps=,tag:tlyn0NSXEGDIbwDnWNLDeQ==,type:str]
+                description: ENC[AES256_GCM,data:YgyZ/wBcpmbC3t4WPwsLZqk9xLoKR1c1uv8QPIxURB9VcmmCjRPanuTt3AkfBr3QVpz8HDCcVrR6ghfDrYorHUS8hx/jIPTfU/s67TGrhIUyYfF/hObssVCf6gXso4msVsCeVQEjysqQAaVHL1ge+aIODuvC2PSbrqaBKqNLS4JdPQi5JsJKqScycAWTQN14wJb0yI6DJ7aB5l0ZhwwmxB5WXJggvo8VSU0lCxcNuRIYfHHKf2LQIzW3REJTTAMaBx2VYW6N8E5NeD2AU7HEHkf1H5ekbrqjFFvh4t2HZK274Wedbp+pfOVtDAKewWSgyq25U2Vb/gZ5hjgmTGHlzEVLlr6MgK+KRhOGu1excLrNjZgci/kwkaRK8K2/aGVLXv++bOg4cOGUpd4z9FdRHWiZtjGgTs0dH7CM+Hc6oBwRdIEB1R/dslPkQ6kd6BjIO8VZETMHnWwt0BisKqyYTzm6S86eP++O4UP9UX7xbBplLTvaaPm/GMENuI0WmQMyFWyqi7NF6ZGfdWUZvw0UmUdNBkwRevic+vuthShfeV8D3IKlXjdcXoWnVwOdEBlXFVgSybxlOVA8/gHYsDvNWe4iGitgdQoQX3D0hcJ3EISUomQzkoDlRtvNN8sOzSpuXXCM70p71M2HBSxYUNYuBewsvvSxg7up+7JqjY462z3dRGMXtFCI2TtmJAByzm5VPGwaQcOy23FB6DNGmeKVXPCLV08QbMh0H6ZhS1bDSvi7vucSWbkS/BkhKA24/nbWgjTJmnRISLEw5vfNL47EulhncnqIIWBzPH5ikptDD9ZKR5M9WRfMnr4HWOkZVlK1RpWn+kd4QE5wa5ELVJZeW+n6DH5P2AI6tHQSoDtKezBjBanw13baWJbJaVdA9gA7ntRbhf0SHkgGEUM=,iv:hA5MN03SGQieKYhuFO5+RmliItB9cmkbWbVkldCwG7s=,tag:abDDzxAalnpx6K812WVNvA==,type:str]
+                status: ENC[AES256_GCM,data:EXM2a/x86HGRBac=,iv:Esgbzhq8EO5gbl8WJrZaudF1DOZdZlK+XRoqAPAdLco=,tag:4vZxhtIP54bzVFyZb0Ayrg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:1HtCix8XO+myHznAGc/1Wq6lL05MDMSs,iv:HrjJOSsa8xpymWEkl3kSPZbeKnOKQiGAmm/i3YtjBew=,tag:6U6y8iSGWXgIMSPbC3CYKg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:5MzhpUY=,iv:rpx35v8hsb0tVSbYQwnXkHPgXCx7uKpVxKt/ojcnJE4=,tag:xUS0FQmmNbFZub2MDBjDMg==,type:str]
+                description: ENC[AES256_GCM,data:ixQqLuvAt8QTtc98SbRwnTZMMFTUN4PSwP1X0ic14myFUl2Ue1HzZU31o8aJhRl1vAmCBFRGvU0aFBHQ+z6JKUXmH4ZC6He00E3OlgoiDqHWTMvLwPrwQlIflXChBcuAE/K6uBpED+CX3CkX2FZRLKdsvQSjvpuizlKZbg5ccugzlHca7BhwQbvS2zFtCKoL6DyKa93Hp3XryCZmczdpnxqeZRHM0fsZZHc63/4DmiVF0DiASIKqAYNLKz4HVSDSPgM6KCLAVE/FAwjo2ME/aB1c03kaWAgIMkxtFxR3YbwkHiZP/mOmsD38tOVS6/quDkmf3BFEBTMSdOKpoz3PNh5NZEnjCsorxKGywNYzI0K25GNjqHw/c+h/dEujqlJoKpRk76kcU6yGcxzESf61bo2JBg==,iv:ghqlTEouTE2t6q6OCife0RN0hvxfKaUD5EPkfMggslo=,tag:o4gE6jE21+J51RlyOs2mPg==,type:str]
+                status: ENC[AES256_GCM,data:z9jMqKVbrKI/ffQ=,iv:45l6b0UBVIirZoI9vrM/cn9O3WRKS1qlN9dF3E3PAhc=,tag:Is7o4TQZ+yVunoQisdJyOg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:aQ6Zq7CgQHfh6HYpd9/YJkIoH91STXxyPIKMn9s0pPU=,iv:+oz2QNa5zTQW+Pp69ztf1laxSFhTrjWeciOoswzPpKw=,tag:XCllGIioDrVQ0/kv1f4Zyw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:OsEhadg=,iv:DkwYONSknDTf6KUjEWetC87sUNKnDWODro/XxM101zg=,tag:rmHYSwa9Ic6mSKi/QmKY5w==,type:str]
+                description: ENC[AES256_GCM,data:fOY3C4LPG5htJeOrLVP2sCU/u8w+riMivLNXfl39DEB1Gmfy1pqTGQhtrGRCmpY9tj7wuVVduru63JnrZlSG8GhhrilbSy2nlcQ34pacgbCbdI38TTJok12Caj1w8DSsB7wFss7EVzXNngN/O6YioI7S6PyW66OqgO+hGlY/j9I5IqxIdh1OIIlSaKXqmGFrwPPC+5Cim+/02bKlj4AHPntNJk+QgorQ/smyT3+KJWIyRlLHkJ6nX9BxKAuJ70sXjUNxEF7UkWNKKvmWtgT2Oys2QE6BUByJcq7/OhQp0DKrEXtqkJw6KypXvJQ0u/lABzt6ZrlIB5MnPvXoRE6Z2wK7Tp/V/bPglp8gHzvG0LHX25kQDkROY1mL/vD70oYHFuodhzGqegU4kUY1WX/Cf4WZ/2Q/HsUCDtq5d87zZhwYwp8iPqQYdeQKesMTWH2dIxE57wnjoSoX4VOW9knXGGiIRaPRgyXP75JfeysYw0xOSCs0bDmOeatz4utBGtuTJRnv5O0okef4Z20vUg1J1fzvWx4asocG0B3N/M53gg==,iv:nwqwEnNuWhnKAM09UV+Dzy0/CCJg1Mni8s/FsaF7g3A=,tag:4By9w+XsS9clVCCqJm3QgA==,type:str]
+                status: ENC[AES256_GCM,data:Rso25ivM1248d8w=,iv:oUN5+kPZKwF4Qo8Pu7BasC/SUuptH8ZsOmOg3oF0rDw=,tag:ctKVrJoTCsuf2+bMR07aeg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:xgkA8MKyehPjL3SHzVNhBVWgYCMUWGAOZW8=,iv:o9AD1/DXNZBMMrQYBdqXUeJXcNAhvkJObI5w4xK2VOM=,tag:i9b/vWEk0NnLKAttMb32zQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:8Ucn8NU=,iv:sxEKvt5+n+0eU9xJY3S+bzLB7oYgoCpjZh+TOxKkVAs=,tag:JVEMKaJpnr4zeorg1uf1cQ==,type:str]
+                description: ENC[AES256_GCM,data:icC+M+H3fnTwpFFrOkKOCcU4yYoUAbWKDpZte+Bw/XMTL/V5EYJTcvcdLYJUxR+6XAWpi6cYsUGL0Mh3whG2A7JhuxWMor98csm/WZ/sgLAgPp2+TbXMCI6fz6AhQe68hUUWYi1daOYa8+Brem7yXfS/9xo9sd+uiFstslxBT2l7A15OV/8TqUcGFI9r7P1oCBAmR+jCwVTBhJ1BeO2uCAyyJD3E1DdfDnfZT8pgYEVCG5v19QjGvQru8Qd4HLgl1dVpxIaVn9Bh0pNTpBNfy9bnDctk82MLPNHZZ9zCU+muMygkhvkJ57r5UKBVRfQIzi+2jsGgLEDj0wIF6LLqLM9g7ogvy0UeHLKuHZEv/LOksHqcWJ//SgHXS3D5cnEB/3hkwpsmz9CZAqMhalxC74ycbyZUFqY2t884ymKUuAM7+47n5Qch0BVJCFhh9rHjn1V4wJdNlRsH,iv:nU4OxM6LLe3RKw2J1XdoqNXizCn4wPwsj4zZth+e0TU=,tag:+S6VFyUtb8uODf4nAkOMmA==,type:str]
+                status: ENC[AES256_GCM,data:JiSLbebKXOnjnP8=,iv:nm6DdMcNJ6EXls7nX93bR8RK5ihR4jfm3WcUYqyrde0=,tag:iL8pvvFvJAe+6+NqmJ7img==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:zQBMDuAgQGAFUghLR5f6yieEBmODmt1E9uht,iv:8+GOCaz9svyADrM54vS17AlNdYn7RLoUPWckdohPhHc=,tag:CK85QYMYPfURz5KO26+AOQ==,type:str]
+        description: ENC[AES256_GCM,data:fTlKzaWxrut7MrcrfSZmDhrdEFLBl5QqIa02EsGNxKBsAgOyX/dZhEZmPvkuFkSGtWkZP+9T1G0sCQaL8PRBrrATI5tOOS+aXyUdxGZA9TYrIl46O5ek3vk6X8y/A2anBYWMRvzZnpIQHlrnGXlsEyTJMk04md5EpVTdnIy9KwDRJdU1fk+uvKJbDIK5xkA=,iv:flY7dYaNMVuMeJXwGdZaC6sLkBOFYLbq+7Qg8rmWSBo=,tag:7Yj7mIyuDVVUST2ESPAJrA==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:f2kw41nKPA==,iv:uu4p0Bf/hWhYwQ7CQLNaNYOyWNIr7px74C20iR1d+KY=,tag:y6dYeOWGTvEZoysRSyQISA==,type:int]
+            probability: ENC[AES256_GCM,data:TwsD9A==,iv:9/XFD+4TNeE8PuPGrolHUqWvxC5qVfmsfx44DR7Bhsw=,tag:JqyR/IQSoGHaL/5u+KcO0g==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:QUd97LMIFg==,iv:xC2bpXXeT3KeHhdJtgdaAm9ZueYZDwMQGj9slKn9M+w=,tag:To4Gc5IgWaj7gmpTCP/IUA==,type:int]
+            probability: ENC[AES256_GCM,data:tQ==,iv:xdIKLbq498v7VRMfq13YZ0AxpXgfeJRxs/D2FjWdpMg=,tag:0uNGGTZBk2fBLeUE5ZQD0g==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:AW0sOH/77OaR6DA6bSSk7tM=,iv:IZ4tx4lyqpbYQV/aysPpH1Jm1Nr6WSc2BZvAdj56QKI=,tag:DblvwlJ0CBg+an+T419vUg==,type:str]
+            - ENC[AES256_GCM,data:cgm/LRdEEElfxIULlw==,iv:WIfzvvV0Q28ktEOAeEjjNA8MdN//AUo+EDi/Mwc1sdE=,tag:Et43wCwMjQgZPJ0CV5OZag==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:jODiM08nIpbQFGqKuB/8v/rpOg==,iv:UD4nd+iCJlL3rxpT06trBtNlK6PuSjF5L5ajtOs4bP8=,tag:AvRlPekqFc/efpMDYLr/8A==,type:str]
+            - ENC[AES256_GCM,data:SQAnSaoKbjP25LlxNQ==,iv:w3hzMCmJKymfpXhtQa6dRS+nX6pYr5vWzufI13MB7tg=,tag:2m5KAI3cizaS4XXzi5tyAw==,type:str]
+      title: ENC[AES256_GCM,data:Fvi0Or9oqP1E6L6Ko9M6fnI5mRxXzl3wET7Cmuq9V3WD1DnFrWlzObY1mBLFj2lZoJgpOyUjdxlyrHoUm6EULTwnkeTT/g==,iv:TnHwDm2YFmw1BpHLal/UmOXgpIwYEhh8WCQjNoyy/7E=,tag:MKaK7NwiUIofzFobYUdBCQ==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:eBRtKzM=,iv:yoB1M9m8HrFJ5Dwn0YM8ewLpTAWs2wuM7NA7mOuB6Vw=,tag:9BfhJHAwXp/DyckwMpqVyA==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:mr+JP1w=,iv:IwWyGEJnC1PVPz7fz9+i1D4gjTTE5Wi3qhKKAoAt//4=,tag:03pcCGJ+DyEprKvve4l8mw==,type:str]
+                description: ENC[AES256_GCM,data:ALIhHkQkfSV3bqbzmZsf5fQTwKnxiahmWhlGFqX4sZiz7LOFwtRGDy8wLmPzCxsqtwJ5Vv+Zzt+1bzvhnXcsjOahMEfLlR1SP5fxmLcf6msBQtCHX522KGI2etw1hUFkOnEPgsYkSG2U64kBvIDQ3RoHy/Mmafe/IJo++wrVQ87+YgSfGQ1I08TgpML4molorYELMa/iKMITiZm5OtZf/O3HszaN3tjPE7vfCk7axO43yUjiV/2b8kLFZXqFwxz7U2aOTWSZL/NI0cSrpuxWe9dlaDUm+XrG1SAtrJ8op1m04a1n/g20ykE8Re81DXCmZHyknG3gR9QdyPFGoaIzx33W/tXrbcyT/cmtNZPYuatlmbSrdIO76pJ+s+HCIwbl+AWCTaa5/tceBh2AR/OnF7KkMNZJ5P7i9eBSp1dtyZAFusSiv+cWpWrNPwr4yiZF6e9kOVCdem+pf4wSCOmwfe7Q2/0bPLfzl2OXWmGJvELlvqq0utrmuDdX+qF1v58nPGUUr58UENiD1KlNw75jQQeO+LZX7mX9ApsdIrpjBbKyLvQw+sqEUovoIgMk+fsdGM7UF4P80fKhm3tE+hGHyglWC7Bb4OTobS/MYbjmRkVmo6bdIlot64d/EHHk82mVtQruxpKiQrS9dY1ODEDwQku/myk7/d1OsRK/41qVMndDwmIi2VXKAsaCpXDzkUlAc0lZ6x/u3tTuQ0MGcf6rtkqB6oALY88YBS1m8tdxZuXkPim4lkkeaHlXlXi6NHF1uYChzcIFlrLlSWgjBcpS5to0QjW+x+i8cXyCKOCI1E7VMLTDb5C0diMHXeHKGoXtMSR99d3PBz36Uac5cRHm0XN7RQ0H5gHh1f8Uar5RPH3VwTkFdp5XNk35Pl5hZDm5C23Br3qP5KDhY/PKf51rf+cc3BuUDhj+GpzGH6QO5F8mf/e558+A0CehZLGqPgn9wzNZFWuM6bFOjGAQro+r8sROsnD8cw2KbCLiCb42kA27B/Me9anjdqcfvdTXkPFsG1XwgH/2sG6nDUbyh977RR3kTDFQlpD1hjiXDsE2InAirLjsPJzr+tZSBl8G7pW8ar0mShJFDqOFf8b8fRlxb/drVdK159KlSHkeECCX+3RhDer7YDThjE+DwYYo3s2NWpgGGZLq24OMTgQY++kKNc+VtvhK,iv:NCHKTTdyW5rdkgUQ6hU3gjm+3jWms0uaCZ+S2QWP1jI=,tag:SbD31iwRvxWwm0BMIUo1Iw==,type:str]
+                status: ENC[AES256_GCM,data:SgP5oP1sNuO2kjE=,iv:HDCPHGmw5rj2ZkeBv/SZ64HxNdM7MrJPu+TrE13HvZw=,tag:7s0awPXF+kX8sYwVZLzJoA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:9DGcobAYbeSljbCpwGlH/7aY1w==,iv:Nf7r5g1guwgi+NBx/rYBd44fTGVmay50Hove7stC8EA=,tag:QhbV1TXR6BelstFYaxIiZA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:q6goulg=,iv:TPrLCtsKqvG2JkRgEb1yVb1jDHj6GgtIFliztAH5ZEo=,tag:CDes9DesihY42I+c6tXUDQ==,type:str]
+                description: ENC[AES256_GCM,data:Q3znyeGfn0p4o8buTFr/CXzfHq63TM11qkr4oJGzm3TD6waf+HpL7IJ2gNsPuXuBHjYfQRQVfW3DlRGR2FuEHx5m1UYajrfHBnDcxjsJ920m3DyvRT6F6yP0vkYXN0mmQZ4coQdWR9mjvj3+xkECEGOr3Hjyzw5jzmrq5GhDYGNqkKR13YtybrZN4CmfBasRcwNipklqKIqC1z9rqKw6uVWcT1grWHXF37HP0Jn+NNT/AlH2PpYx45URhCERDuUt1g90k0mLM0V+fHiN3AyLJXD7vUI972AqaWSvX68LAgSZ4Ua9TJQ731sZMi8nek4+nyEpdmG2+hZZIJp58lYKsCQnJrYYYY1gWxB4M5O10QCR4FAMkTKdlXfiSYISFO10Lw==,iv:iIIafi2R7hsGR9b+bPEWsdyz9smavuRcT0mmQhK2plY=,tag:A0zSyuC5CAksEvWRoeMIIA==,type:str]
+                status: ENC[AES256_GCM,data:mtFLZkm/xDyLPKk=,iv:6W9IDRGi3lbdfzGkIlc80VdeLVMzktcP5U5635jtA8s=,tag:28cm6lNfrOeYS9GO0mEp0w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:MU849zceqmYHQl1/yF8wihiB1H1oMHG3,iv:tyQEU87BRdTXjgl1RWEgpAERDtpVVmkiQM21fLhfmEU=,tag:0XJu0VkkYNeA4KC7lmAIXw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:CVCcx6w=,iv:JwBeEhHiH3JjaTTvktxZ/ChjEhuDvty/5M+khm8Wwro=,tag:Qeq57U8Q6Vbz8K0dj6OEEg==,type:str]
+                description: ENC[AES256_GCM,data:FUt7Wn8DiKB3PB7hPR95V1ITVEa4iM8cslVY+GQDcBffYH6nm0+UqB/zR1Yo/0NZ1mFNEZwaNv3tNjeIM6AOoc39Gw9pf7WKD3gs8e/UngY1Y4SxPjBtv/+xZb0VOqytMxFld2xeW+45fyGTQvtT2cMyd+eDbUTMee79wbgmG9LfZU7uu6jjAdCiIN3wtE/ykFZLsNEY33l29VYzyD+oNedMG94oQBiRn9HH+lib0r9GP2XQNQSuIoidD0qY23YXSICnj4K9dtN2EdCuaaTvOUuRE+HTjoeBnWReh3HzmZkkuEyGyRMHITS7rOBGShU6cnlewGegmS5yCsbGxjidhyD5aK1+AuHH8rQCRdExKQ==,iv:nE9449YxR9zVjcsWiwv+8uyPJ2rDY9gUL4hZQq84S40=,tag:Gd/nnOjQ2k5O7VdUOrVnJQ==,type:str]
+                status: ENC[AES256_GCM,data:93gHcfqPCLOfjIc=,iv:LOACf9G7G6O2L+OFI7EfNTn9RGXVSKAL8TtrbNPOYMo=,tag:c4yYtWFbAbNKT8E4DbhnHA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:Lurdl0Wdr/PkRhSSt6Z/x7hUow==,iv:pmPi3ZtoqDWqvZNry+9Q/e2Tgm9f6jjDR3cT3Z6k9r0=,tag:DnVX4s+86Jy3MzWnuxZ2RQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:ASU5KuE=,iv:ZRA+gUoM5lKDq7fQqhMJTEhwiBgdZxvMrZLdCPY1WI4=,tag:ABFBhT/cVWRjjtH0JAcDDQ==,type:str]
+                description: ENC[AES256_GCM,data:jk2Fy3aAGcEhiA0AD3herRDzUKNr8KlRDCU3M9EjdPhEwRLsROxiVmowLw/sVYTO2z3WjdgdcP9MO96dOCScBYjQImapYsImBiBCfxVv7fE5bsMn4eCWD9MCXKwxmm3JdUtouXn0PIGz7Etx5tClltOZu9WOsfZUze2LZab2mZDPJKg+M8e34dTHghQyOT67vavhdS0gj20fiHfcE46x1HYpYi7Tm0t7JWQDjZPhBBkeNTWFcMvLnkTuIzoWbMe/5jezZ2YYZDgH8A/tN8VJ4utccrNeDH1HBHU1tf+ObXrZQIXH3X3lc8YCqvf2WwFteVHk8H7iO4PptEwJYsFm5q0uLcFSOoqVzeZ7v1cwDAbUyhuxeBo/PRWlQpiSy/L6rfHA0xIkWg8dnNKqxuS9ggtfUfk166GylWn8tcPtzYa7EY9NPuU1FC02hvnfJfS349Z7t4vlt4GzeAxrapW37gk=,iv:0dxMfg7jllCQxVZPwUKatMRWUmtteFNyBn7lX4lQyHU=,tag:yVGDDrjOKWERFQD8ApGtzw==,type:str]
+                status: ENC[AES256_GCM,data:J+JWTXuLVpP+xyM=,iv:NB8lqH9UrGoP9aKwU+nJfBxzWVr8M0bZjnDvz3+gOfs=,tag:6KtAge4nuPF66LEG1tBG+g==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:5Y8X6DGeANovWaKU4TtIHXua,iv:1XC5QK+xUuoANQuufiS3FD3OGW6m9bINbV24aDCEyGo=,tag:mYZcRdvL6H0G/YyqOgFAfg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:oqoUCn4=,iv:XpniQPwMTDhDxCxsjQJU5iv9pAKf1js08qmMGEzn8RE=,tag:XfR9ZL0gZIoFb/V42HzwjA==,type:str]
+                description: ENC[AES256_GCM,data:e6hpeQWSahgNV0W1p2Tz9JmtDKJ9P0pvmNPFB9JccZK93NW3ogpKd37YgP8uYb5MzbP538mTG0lHpfU+uCX7C8/nw7X+DNn6sDCk+LmjxAj753SK+R72sTTMOtcTDP+J4vwj6bqYi10a6X1ZLryrapaLRyBvapAJ252c1Zc0cjhjmxrZNxRxFjS7lUKd4OTZ6yZuvPRJdqgUFjVUihaQ15FndZD/tcopzIbRlouCzUPUqCTLBWuKtCPO3kOxoea5JTa6/YcemKbEk120iPCgDiXj/paRFk6RP3Q9ionVy+D3cgy+u0E+jxVFcVjAIN+aRaqa0WdyLdHZNfG/HgHjX66gTAUpRU44m/qg8L4=,iv:ebohtllRPkv+UHwdNj/clX7v6flAcO9b8+AEI4QyA7w=,tag:wdno8t+xdXE7APE3tXLELg==,type:str]
+                status: ENC[AES256_GCM,data:S0pnjKCbgfprAsA=,iv:BNA5UrNSYacGWsUh8ptX42T0547cZUYrGBiLMXlrqMQ=,tag:Bhx9kqDJpLNAnnNNwe9PKA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:QjX76clxxzxG3bgLWJgz07byqkQRZ8aa,iv:AMRMmxFN+oauCCB3pVyMcle50WhEDxmFnxf+WFndE5I=,tag:hFWYJLvvms0jrakEGoPUvg==,type:str]
+        description: ENC[AES256_GCM,data:K/RlHmj9GN9VEOF1sANgnLXWsZ4/cdiLJZG2gUgdGZOP/naug26DZ7sxRQ9Emn02XWq+KHFe3T1W3x5zxLg9G+wTgR96KLNU046yiBKjx03oeMhgvz/sHyH/Sk7P0ktG3kb0ViQgMIFs6LV+fHWrdibaZImW6pfwYqaADwOx5bZaUjmDqszgSZ+hVIiAiCIFnpHdzph2ibKz4Kh0nU9X560lbrINycvjXm30q6iEP6CRWRzrdcczsmNdgeYl7sCfbCbQebQmFk8Cb+ZpssmY1VTodcHtRiK3OrEATZJ6TCsNr9fr0kY=,iv:pDGVKUMeN8OyYepPfouFFAMoOqUw9+22tYuTioRBkqc=,tag:f+cUnkzPsl6/L0lDkRMe3g==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:yI92t8N+fQ==,iv:V077K6xfQGMoQnQ78mo4LaoOlzhGxE5I4wGMgi//Zzw=,tag:XgcCTvw2sbXjTtaedaNwaw==,type:int]
+            probability: ENC[AES256_GCM,data:HCUaTg==,iv:58tf2hC2xihqoQCR1w8hVvYEgVmOpnVRPmTZOmn7fBU=,tag:MS7qo6rZQsZTXdqYm656Yw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:QZcMMnBuiFA=,iv:N7apHuR9CE5jjOZQF7gkFpXLd/bleuVqDXlIHk9AF74=,tag:K99O5n+bCbDrfDZf1EX7hA==,type:int]
+            probability: ENC[AES256_GCM,data:ig==,iv:IV3UaQonXxQOmnXpaiq+KhQsLFmqzsmFuE4nGOJ6My4=,tag:jyTfFayOIeR+6bkTKVgL0Q==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:NYe5GkJTLr1/fg==,iv:2m+IE2fLUCPDqmBhn238y24f9lxR066fJo+sRLevUqI=,tag:RVCsR/vhH1vNAcgWMyqiaA==,type:str]
+            - ENC[AES256_GCM,data:xA3VVVxzq3VC6hWNcA==,iv:KhDqYG9foN2CoDHWWeRrjrCYDhBKgW7KOAAmTtaRj2g=,tag:Aop1bQGn604xQZWjTRSKDg==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:u4dW3I69GQbx5xEWTnqE8A==,iv:4cXsMUSHfwsl6NWHWhYYdxzm26I9y3VdGTjSGp53vl8=,tag:60+wmx1BKNgKktSZsw9Aiw==,type:str]
+      title: ENC[AES256_GCM,data:kWrBpk3ezSnFzo8c0mGXTyPQJfnlhOXZuplVbfgaRwJ3Gg33DeMq1LyXxQmRqULSuuYMrYY3OtqJpIVqwSR3+rLSmJ24K/oNlkKJ0anUjJ1euygFV+xccPmKb9i948oQ5jOefhFYLGdL8SeOTg==,iv:OqxqwQAduV0GdOq7tz3lK4x+SJaJjOMJ5GNYcooF2yc=,tag:CxyEJZkcDS2t2CSroEQzpg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:fktHtTg=,iv:+JA4GRAMGnSLNhRrv6kKFkST172f1GHqK2Ulm2JPOcI=,tag:J0C0Frz1yc/NwGSpe0uE8Q==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:DwYIggw=,iv:qP8Du27SlOkjznLNFRslur+oWdBTUas1iBgfoRC0uxA=,tag:EEO7k8LtlrsVNyV7eb17aQ==,type:str]
+                description: ENC[AES256_GCM,data:I7R/jqTKckZ4Y62d51jDSpzHs96N3UjWBtUYyCtoWF0sTrhlgeH96+qoXBo/BVxjvAu+Pbypz/bqLkfpIdPLGmtTs9cCB4mBFRCLxmX/HHeZZeEPbdC/s7j2tPtpG/3+uZ6Cvyw1v5GwP00aDBBCq2fINjged+xRoDlk8J5hg2OvgcYIo5w87vM8xZtyDnKLq1oEvRkWchaivWTPWzwEVbWPTLFbwnlxq53eAB1Pa4t9lCNPeGoTgdF5xbpU5Cc/XHBD1fWGQZUBnXaHnP3HV8v2Z6mASzFuDeg1GyAZv7EsPqvr6uxHQT/XSQ7pQJMB8kBYv4WNkStahPs6qd8M7VXhbemzOd33lzp+RG5d+RHgGinKu151bGRtJvs+fn6BbDEQHQjgNlfu+8k4CMvgl4w/DRWK/TK12X7oZ+zxeoTLFfqpKBCFJCHP7I2B7ykJlYwI4/wocfE3DoK09//Ir6bJ0lZceNpWiqSSxuOTfea8Tx4Vn0hK7uDm7D7zbg7RtvRPp0ezXnT0crQXve2zhVAMv14=,iv:a5V7N9yhxkn9IGzPHNlPL+BOvZ7GE51+upRI+Gp6OQM=,tag:pQYqJ5w14iOFPfiuHAaBcA==,type:str]
+                status: ENC[AES256_GCM,data:UWUBhZXehEnIEy8=,iv:qt3N2NT67L3adgFm3+Fjcp43BlgewWDcZtHIoSS4OFA=,tag:TKFCiKaUVpj8IcLoLlcGEQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:q4jdHRgZpttiUDy3ScriNGEVVSo=,iv:9SbzmXXXeo5rdvbRs31prftFMVa0owOv4JzRqtxn3Dg=,tag:e4k6G0LW1JavwoqMAkfzsQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:gXgoXFc=,iv:8hZEMwLqBcG2clgPrZvaBrSS2Geqn4uYjuWYziqIXi4=,tag:EItEZX8cmSIOidE2uzhJng==,type:str]
+                description: ENC[AES256_GCM,data:qYAId+f+4VMEMgGnHHDQ8ZkePCga3/gaE4UwyMMxk2WD3fTlNmUBrF5h+YvuPrcGvI1dRjUeQ0ato42ROlNHVrFTroAxLevAgJNMRZl9eFVIs6w7bm3oJkq3lPdNkx4M5QuSS4oRIbVjv8c6RgQKktCVxjJ3FBcTLQwVf4wE5GZuJfeUJtqOLNmoMEc0r0qv/7x4PIoQSh6wBxdCEnxfPz4ICAoY66KcwcQgSTQ4os+MBe5OnCr5bnwzeOkK17WzXQweGk/2nE8qY4E09e1Ajf+J4gIeY+TJPa1npJZF774o+1mAHV7+MXzDKY/bWufu0zaeJ9rJ2/wHUW//onsfa0n7,iv:LsO6jbLrw382iroqyaeHY+3goiDcO/Hh/eSixyVDPco=,tag:r2u2V2qE3+aeEOcdgYqKog==,type:str]
+                status: ENC[AES256_GCM,data:Wu1Ns04G9srpAoA=,iv:AV/6fCJrO1M9yqPGe1w1IQmLEPhqda1o0TArExfq0eY=,tag:IAKQ0Xgr6C4cGfngmDRLug==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:6zS3aQ9GDxYBmnfV4qC/7w4=,iv:h1KVQZ9ePnNo55l9pimqLc3AHQ+2a4mT9Ng0KcoZ6gk=,tag:CtprGi9fXXeahgCT3lZYVg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:/LF6rp4=,iv:cz0deCwlG+V97EHy2H1BjaH80Dr5PaGjb8tGAtnk/DA=,tag:Fen8vDXjcg0IjFg/zY+0LA==,type:str]
+                description: ENC[AES256_GCM,data:gpYPpqrem2oUaDQYbEEXSxYGya65RUpCpDyU6YfN0gIfqBBMV6hHpKcc8pBiNOAOeOHA/icLuK70WL2057bx3YU08Q00QKOqpRnZbCcbmt4uPmDMefFwKsyZ8/ruyjhCE9SIwxFnVjBOvLtxplmCS5Vt0f10JOaPHXYmcgBAILF7LRDSxNmnIYaTXJlHH1Ue2zJhXK3msk6udW2PYfZ2gHrKUbsyaK/OfMDD3HmFHGz2+yHET5CuLm590XFTDGGmkNzXYH6h6TySDZz3TJw0iZITEFCLo1QWGpn10i/PR1DkF2uMSaKWQeKE46qk8EHM2ZuDsyAh5x9xeAyIAsVu/5vx13uTwrhZzrkHdl6etftRcnthfFIASRcc9jU+tKOnNZ6VPzYcrs3VmHw8aavwp18swtQSAJPqiL5svPwTqtUmYldQJTr8dq90ld6VQzVgHTFozb5wXNaD4YFI/eCkTWzKuNKP7z0ZZv22iN663aG7qtF4Zou+J1Lr0zQ6g6uJ3yWvMQ==,iv:QCFP4yJViho4mXUataDxJPPBNqK7ypFrpUgjh3eJyxU=,tag:exhC7TtOoruegEjFdMrlmw==,type:str]
+                status: ENC[AES256_GCM,data:Xuze417rR4G+wJM=,iv:iSR54aXYPL4Hf82o8h1arDLnCe1CUpDZYTxz6ezTHCg=,tag:vfkTWnZrr4dTY+VqfWuXmQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:vcNP86R+bMSLNxHw1+dB/bwObwvwSQ==,iv:YDvbcMR5LRx0lBzT5uTOiH5e+vzrkDzf9GhrncFKLKg=,tag:sKLu2UDkKAis4YWn7bmMKQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:d6bvjnk=,iv:nyax9fH8e1L2fU2acYgoy9uaqNxQ/IBQJf4xb38zzzI=,tag:4MTPmzs6W8DD7KkiGgj2qA==,type:str]
+                description: ENC[AES256_GCM,data:heP6D+hpSgYj7L5ntLNuHQzi4xYquYl4bPO/zO8fuxf1fN+9uMti3KdCWsx1iWo9FbcX+hhtyKlAVL7Qp54n29rBnOOKlczwGVhXoGSrnH5lJc2mmkHCvCi7ZQaNpdnXKkDaV/btj3r6/YmcFFnmXjv2CyKZPealrUaDcY6MTwxEXqlXil8LnULuObcHvfEcvvEi9GVNIBWlijisljtxrdtVrDmkMZjHeE2ygwVU10vFTiTnQf6A7TOPvlZWvtFc3hV9wqznpIDwsQfRiLXARx84B0nCNkV3azMC7pdnJKfdHReanryp6At+ngNbBHatU4icdCIcG3QXDKg5ClBWHGepqhw7Lmfi4cWAsyWbQrAZJrI7avth3sRVUBPagjwHKLPdxwolmMwMXQfnR+a0pUsmt5Z9OgykTKVO3V1MUw650Dk5p9DuGB2j5jfrFKH7nSCyRkZO2V0oz49rc0BJA11Tz6pdLib1HKEa9Laj,iv:KY3LcsKnZBsq7EWyUt4CrPA28tSCJvgk0zFyyBC4HGw=,tag:QdZ7dOaVoTQzQmlzfZMNcQ==,type:str]
+                status: ENC[AES256_GCM,data:hVOJpHWME68AOxg=,iv:N7zZVQlMtC8GFIZWdLPW//e2VJbS3dSmT9AIJcFm+x8=,tag:ds1eK7gmvQtldRvSFsaxCw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:mZ51cPm/RtLTml/hEusCYE/D5w==,iv:1zunHgABBMfHy1AcZCm3OtaWot+sm3W9Jhl+8rKVV1k=,tag:SNt4/2HUAVNQc2nBMYqEqg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Vs5wFuA=,iv:ZSsbxiRyJhNp9fhvN9eT5Tiavmr9LVfwgnYyZ+rZ1d4=,tag:vrkWFdo+oLSh6jgjJ64iSg==,type:str]
+                description: ENC[AES256_GCM,data:nz5wwv6W/gdvJLEWNb93GcNKpsXfv4sOLtx4nF3Lyiq/w+i1+4NCmmOrWh1icTB3e46j0xSPAnKL1EQsRFxQZijpVlo9dbcd86PH7mJdNztRBIUeoV3yBavi+mgRnHsSM5W96bJdVlY6LaI/GHLSfYSwm7OrVGqH9foKQO6wN3sxKcJiS0SgQJzoMhyVyieYeFVFW8MOz5sgzNJoI9hsvV5ogsnlDIS0smXlXCbMA5v6f2w3N3tknaXrgnDixR3Hm0UaAh9B7ZiWLNsFiAYCuorZL6Zg66arIYPQhdVo6U47BqorMaXl0Omw4Vc5hDZxTZsgKo5SmHyjOvR6IO/sDJcBo5pLcJBNMuxpf6v3e+l7Pz53I21gUHyU1M+bQcHY6w==,iv:AsMAIk6pMFtFBvCKxh1KQYrPJ6jo7rD/rcyJEef8eWU=,tag:w9KpFHDNth5L2nEv9iildA==,type:str]
+                status: ENC[AES256_GCM,data:5glNNcpyQl4RMVA=,iv:mvTtd+VGZfIByS9J/ibqrtYfdQGZchxnW09ZvXnNs4U=,tag:NrHybpr1fmWBxUIEjCTUQw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:fIiGJsEE9OVzTh0N3Vk1OS5m5g==,iv:CfCpykDW5n6521N6Ef2S1udGIEJbJNdG8gnkmIOOkVE=,tag:x9tPwkqJsthzHLaRU5kchA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:whYqNIg=,iv:/ygWsiU5JYxR0ZteDCyLBBp+qo6SFJFtuj709VhyLUY=,tag:UvB2uTcwjDbyEqHMirTwhA==,type:str]
+                description: ENC[AES256_GCM,data:mUomtUxO7viVu6YQXiRZ1BgNumuZT/yTqgUvTs09lqG9XAWY3WtJtGcEgXgrIj9DshpYEEkj90HYENl2QF1XcHXIWxDodoS/uWRZ1Bvj1UvzQmKtnxH/coTgblHa2pF2XtAFUb0MSB7hipTKcnk528yCW9XWVtJ74vvXtxqLQm/Sq6MgdpruG/NZTfeUNfgz7XSvHSQPy1msG8/JVGR53ZBnfvmnlsPX14HokXfXOx+AIAZ9yT+sUybTl05WHaKhymc6V/5Kfex2b5z4RuO7c2xhooW47Tjf7xigVBAtVw3p/JN027rXenrRxDCyhSgvmT9ElqWMa6tNnrZwCVfysVcPmVhmDEmObycy0QDyGRf+wFG4W19L,iv:EW/nnSu3zr1t8pPSWaBBg+wLmePbewvTZPFStnB6hzE=,tag:RzPtkaHX5NH7yISTMxc1Ng==,type:str]
+                status: ENC[AES256_GCM,data:XSMo9+cX2FqpLPc=,iv:OzTaiixBqwKYn4s59UsfmYLKZdlQi/PwY+icSb+XyEI=,tag:W4bgf/J7MIB2sOE2QWIsaA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:RcOoD7dMJibtg0zAEUPt,iv:V0TCILeg13OYqGaFTtFFbDWzVx+1bdCqm/wocB5wrJs=,tag:r3b/JnXsHlvs9Ea33/w+vg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:8m5LBQ4=,iv:zcOsNe2syBt3EceXMTHI7jDDYRql0uX4ItLVRRSjePc=,tag:pXGrejnYG6c8LhQbfTUFGw==,type:str]
+                description: ENC[AES256_GCM,data:jp4FRFhGjACq3JbKYtx3lvDOUvDWiAzdDSQOTMESV17y0/oIS4p3xQ8zIP7pYxmGj8b1Hy8GA8vTYNMZeDvnHi2wxm6RgHkDjP7X24fMzHUIuEoOKg/eKb0DUcAUnrcem+LqbaaVIiigylhUYJrOl2oS5mEJdNO87qTKyc1QmhfycastIOfWhWGoeObGELhOBeA8f3T/3gkhrSngikdVzLXTSZF5MSAoLYRb5hP/Q+QD4qUEELFeRz1/6YHyMggjNjPSQubzoCXT10P9qLc6/QZfVk3CIyGuxQ24hoE3ko/3bdFw4ccWEtFEcg3TpfwBjYJCm/kDFZpkqTovEVRSMePUDJ7/4QpkbFwO29Sv0WFJEVq2zuLvgvJFxwdEh0BPrcukdrEM8W+wO/YZr5k8+8kH5FYNOLAkVS7nH4PJf3Z1yQVex23TyMYU1Zm4962iCX1qkLi5q38J7s4olxHlpDIyIc1KGCmzGpkORZRx/NhazoLHuleCUu48fZE5GdEM0lCS5wdzKSF+voz7RUnp0dlkMwdPTq+RGG47GsRcILMJx5b2piQ1JWK0v2bkjd0/smIAvrHuaXYlTjo/uSW91L6ZaKaomZmQ0U3leZ2PEZHQ64s3bnWAuaEL9ilTt0v/rep8FjcA74QN8X0a2Ak=,iv:U9lyhailXlfS7bpPk/RnHgvenf9pbrkyLu2AL23s9c8=,tag:EFO53UWMdxacuw9rC+4FIQ==,type:str]
+                status: ENC[AES256_GCM,data:CiSr2NPPoS6BfI8=,iv:nPzEjOh2jgpi9cEjlRBdDlWi5qB9bp/OJL/C1+xwQn8=,tag:JQzxvtv8CigSu6S/HV61ng==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:hsavcZiAEFGbVtuHxQXbzt3eeSnIdbOQZQ==,iv:qqSWB8WA2HD+98OBC7wNqT4hW2+rz3ZLtRQF6+8vk80=,tag:N9l87Qgldyr0mERt/DiO/w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Z35S49w=,iv:1qpYljty387aHKQnn3WwKZWFqLnUXNs+Zu1u52vVi58=,tag:vASyCjEswD8vgb7a+BikFA==,type:str]
+                description: ENC[AES256_GCM,data:ND145kDeSH0KEhDIrxsVarp2n3m03I/6FYarX30OXI5baB77XaCOoaDYneaYU3/XhJ8UX//eSDoN3gZ58yUnfllVLyoHdX7gdUZRPLKUgwr7IgI9eoUSX+75Am3TbTW4euCRhlmvsCi2JHQw3tMAaUuNueextf9LSvnwfiGpNwiYwHDe1toD9fwZ19l0ZTkTKZH6D25ZkygKo0yEBLqly22CXw+fD8RDCXHB1zmZOdk5er0ve/m6QnBPauiGP1qA9dbPDR6gEtXvt2GdrkgT8LFNg7eCRFCriLLywh8FYcorlLPSTMHuZX8pvoCvHn9d/HOE8XaPmkOfYvEcZyYRgwppU7nLHIGpT/6/ADry91QAk0UxBSHxyJAi3a1/lx64RH3khx0PTX/RoSillhABn1b2s59GMDOswyVwCA==,iv:ABHisqVjchhcOnxL3TBffrq6MfzL7VoqzZkf5gt6uz4=,tag:bCQ4Hjkv1gC+roL42vgOXQ==,type:str]
+                status: ENC[AES256_GCM,data:h0cE31S0rju62cQ=,iv:eiAXTKPAniNUqnChebiep+jG6wxccwfBBP/QVyXdu0U=,tag:taArh/Gepe0PqEhloy4pXQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:8YGyiBTJafyIHYv0o3DnM6B/1fGg,iv:wTOy1yaeOOrjHUXoO/J8XLSeDTvVqOt/w/9MbBoNM5I=,tag:zF0dGRPJJ3V46yqkPSGixg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:bMVfhfQ=,iv:i4q0Sv3zBatcvyCmizGSIFLO7xRSRg6Orx6KThoU3M0=,tag:t9ov3wi2e8/j7h94uiffSA==,type:str]
+                description: ENC[AES256_GCM,data:aHqOw2PhNmp3qwruirTp1ph3N5yrtFfcyvDyHAxh2GXhvvXTRVihgBiLg452VghGAJ1+Raiswv1be7/5dBNV0KsXVVaAUCtEwwcKVU9fy8883fe+buPPf59exoS/msly7OBBToNjGqe+R6hIu46eiczZWFjjuG8n0uzjN84FXEqmfLXH9Hrbkjf+Ew2Ik5KlMmoqYdDy0ix5CQRyML0VadV5MxZHsQbAsXW26JtSLpSm,iv:kFOIiPjTz8GpwkK5bOLegeSsiTFmet+OgTUY1WXch0o=,tag:y9FN3Fw29EKhts2/mIUqpw==,type:str]
+                status: ENC[AES256_GCM,data:nAPit1G1mzNWjRY=,iv:IrUbmPqc81wBMOPggBYQDJ5aKjKTgdClHCtGrcnBWTc=,tag:jpDMaMrURrdPjLGepN2eyg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:3MvFcBoSq027YQI6aB4vKeMfUEiS1w==,iv:alf9xkcWsHE7Qw2rSkuu7p5kHQaoD6sArccv8xFtKA8=,tag:7qGC955HGAt26TeeoW9Ovw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:wiyO5KI=,iv:odFl5oL4Jl9Z5YctKhpKdcFpNrMQD/yB2FREwuD5xi4=,tag:MQxkS5mxCUjuC5Loqa8g9g==,type:str]
+                description: ENC[AES256_GCM,data:xfV9OPANI+bCgu4mvJ7KIzB+HdY2CupUTQ3ZD1+PB+E96FGSD29p4GNgcjKISF6JPKfGDymETVmng+8IBCdRyo1MywxXX/3vVLL7rspiXw48t2qwaWUSoypwSF9fGg/hANWxFWU5nM9wWwLOOSmCXEQc9A3lw4PHC5bLAN+26CbXpExTSWDqBVTmOQCD8YujrETIssE91ylb64sxpr2U8GaNq3GlZ6Nm8j6Ugzb6NBepTlxN1FuMcgOncA2NJey/7WliCZbYtYAHyfWFQFj62ii1mpHe8YXBlrz5cBT+kLfLMsjdVzvM0MTJaUeQYVCzggYQafm3S7T/MWxsrqWDlVz4myX3e1goDzXkkuDuyRkEd6we84IokZR/MllDgXAXBoXQiBDmyFOCM8d6CqFhc3RS2v12a+4h,iv:2HAZICpEyofS0/ro43vWV4qmVTT7WyHOLVMz2AvttgY=,tag:EvakRrg/YcFf1JP0mv56Ag==,type:str]
+                status: ENC[AES256_GCM,data:ALrI9pqG0UUi4ms=,iv:SURTi84qF6XeKHYJhPeBU0qE6rDMI4jRB+tjeDQZco8=,tag:FaSUIHXWSL2tfJfkEvXprw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:CEI/9VESYk1HpBPLzW6AVIUQIA==,iv:zB5FbGYE8OStwfOnE8zQMcss/K/QQCj4T69wRdAZYtI=,tag:CKCRQRpW0y/p1fohIpiZeg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:vn2FNKE=,iv:xx8qHqKhvN/mNH0DTaOQVvc/7cUSEiIrBSbVetdOyoo=,tag:QJEzULuauP5lcjsCt9wK7g==,type:str]
+                description: ENC[AES256_GCM,data:wx0vDNpfOrahB1qcQATIHvqJFg4bfS0x29H66NpWHVq0dNLI2NTOGYuODpKRfC6h81rjEHvdooP7ldlsqHC4InanpOeJJs+UKO7HxaJEt3HcehZZdE27wL+wdukmmqjjfJQoZiwxo2ZpjF39/ZSGKDw4zqdK6JMclXiMqh6X8jw2hNW3BPU9/EAz1dzz6FbQLiMPiTxEOyJOgxn/2zu955Rm+ZBMBzG54dYXpBq++FaTXzO+ASM=,iv:lZHV4vsR0KrYYQYXQYvTsSOEtYrlSVSGsXDQsNQVemA=,tag:279jWweEZ192HkgyjCefug==,type:str]
+                status: ENC[AES256_GCM,data:WUI2+zXd/FBjrFk=,iv:ZiQ212j209civJcSI3q2hv2Pa+f/9+anmV62Y5/o1/s=,tag:qvzTM30ykBu9NibrMLGQ7w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:EhJDRZPI5lRmVmAOp8+XBadKmMg=,iv:miE4kI7KQ2LfIjhM0mcVsh9kmGY0ZVQ14yl3VCOawJs=,tag:6UhIOJ4VBJauELvmPb8uYA==,type:str]
+        description: ENC[AES256_GCM,data:wvarfjIJrlNrY2KmnFfJ0s0Z1XghuIphwCuyGiEEBdbJM/OrYGLRfTamWxNP9araDLtV6jpGxMH3dqwYpmT8s0hiM5fNYKQwpWS4ZcaVF7cTSxRQbnUB9OxK/T2iMpcGTcC5JtRST8OZWLA+OUlG5FcHlo45F7M4Fn46Kpetp7LFOzHUYcgjOuixioOmoeIKWxI0dR79yTLgb1sksjlLLW9FdGr9TzaxVVYe6Xus46OLuA+/I5ICNADyZcwPMw2c3qFKZZy1o29n7dZUjg69EWhQJ1QN9kIt7CE/iuWPGxbTTJFkdCKZfWJXWweU3LSP0H+PWihO7yGv3J7HW0vVbTilokI3gw==,iv:TLCa7fErT8NuyRmdPXdWbSJ9e4XjQuSynXYpbs2OU10=,tag:qmhz9uLLhWNrX0dK6FwQng==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:rUcf8m4qUw==,iv:P3AQsVGgDppOKDlIU5bdfyEvtZstgCIZgL6k7C5vg74=,tag:rWW+Dti9NaDSGA0TSgHx0A==,type:int]
+            probability: ENC[AES256_GCM,data:xu5APA==,iv:qZrbX7OHb1Fa7lIGcvQIJ/F4DE5WprRYSTUZW9hKGyE=,tag:CXR83pFzaJdMA1+XV80mgw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:kSu9ljlEdA==,iv:VOu/lJ9wKJPZ0rWKmoH848DEq/BZT5qWN5PoV4zMZiQ=,tag:mVhSiGdI2NBIPmroDNgrMQ==,type:int]
+            probability: ENC[AES256_GCM,data:NGs6,iv:p6D9oZDuAzmAjXNv9LoX086hygRAu+ppDXM54TagUOM=,tag:4qVpXdH6vxpx2TYm4Mi4Sw==,type:float]
+        threatActors:
+            - ENC[AES256_GCM,data:NBtQD3xnlfllEZBOU9UpPVc=,iv:FMceRP2Irw8jOx3X1u96s/C5S5Lpv+kryvHr6o4lLTs=,tag:XDrd2aSQa1/M9aIt3MLZwA==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:ryPT01PqZ0+8/Sz5EyOsU+MDut5Psiqd,iv:ocdKNyqN6CxCzwmnd9TT33jkAA3G+LTum3n8qDc10PU=,tag:W8Zs/4ULRlK4s6fLqAjmMA==,type:str]
+            - ENC[AES256_GCM,data:4MjeYf2OMmqP/YugQw7Kog==,iv:nmF1uj3phHdsRRiBkP++LKbfQnQ6IAVovGXtC66cn4Q=,tag:T3BbTOanV9baFjXuNalkRg==,type:str]
+      title: ENC[AES256_GCM,data:9o6xE6eslnedvRvpRogehscxYfXNckX+/0THZhmgyDLAg5CDovVNazaDm+10KJ3kC2FGS8qE/XfDhZC/nZY7AfVMQ1EhAmnsyJRRYvJG1k1+QYROcNW79y/ik3WlNfg=,iv:PCr2E/OTQyTXYRUcOqYP7p8/566s8NEdD/7kWsI92X4=,tag:3ANNvghmaYXHrgE3y+X8Aw==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:mXxGBGo=,iv:vDdiIIg6siOJMHWFWszc+49r2qrjvpPhce0wVcInr04=,tag:Z4TbmYMtyRd2nVBS9mS+oA==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:PB0NkIs=,iv:1btT2kTT8pNTICU9XP5p4J+fHOsTSxOQBVzEh6AFCVI=,tag:XiRjTIGsb1F0pKM7QGpm6w==,type:str]
+                description: ENC[AES256_GCM,data:fA7lbqu/ZAVF3UFRSms2cf4J6p57MqxlF/TqCX0dK4AU8MyyOBZtYTSds2S8rUXiZVd2b0Ja3kBDYAeRVq5Y346yPfPrvuMoWgbM5X3U7kPS5G3ePmj9YrakRMDYE0EZCNBBlBnXdLM/TY7xp7gOnYJX2FiGY3sGy3dIXymMsfV7msuXOU3nJlIzvr2M/X7ZSnz2lV8LIFy/PBpMYdLVkIIdCJNcyd0OcCXv2UFvQfHYUOpNuT3z9Zc7t3Y2/stOy6a2Ip9XItCOP3Ae8qvWdfs705acI8uOyf0Q+SLPjTcEDxgYRM0PPpc/zZgk8hacH9f6A6qfp6A0xCSUxEx/zhSGkmJz/nTP3dTS7OE9IKYxBw8nspwh+S8SS9iLlls+eAcUR5AdOG5Sb2Ey/l17Q8a9PSRrhN0f5WHBXbbD3U5PHC6BctKJV8GiKZu19WVJ4uRADRkrVqvK2q7sGcetFpC1Anns6jHyXpddeWow3HXuV2x44n3EXE9eyi2/Ip/kkmB/IFeQAZ1ZFJNYJQm7Kbjol1zgkaZ/nmZMZiVZOveq6kRlXx4HLKqzaKp9tioQRdA2+rIb5HnxgYbKVplAo1cxuFj9CoV1pO28kU8n0v2XPXp+/qy0zNyW0OdtTJsRb371K+RlYb8E8/BJn7gjOOllqEkdp8Pg3T03WXkhgT3jDq2YEniESJ5+qbWKoy+cpu2s,iv:ZX0fM9amXpOErysv76TgoGN5prDl3iNZoW/dGzA5GHM=,tag:DjHsCsviNTLU7ld+aegnJQ==,type:str]
+                status: ENC[AES256_GCM,data:nWCTlE0PPAqkAT8=,iv:umGTJYDRIIuoFVWjrL7GAtS8YMZPLFuIrl5CgfBCckY=,tag:BuyOxlajgUhOFfk5kYKPqA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:3ylh/L1KFy36AqkMYiAcZ6r1KDs=,iv:e56+jFtx/RtGcdeTmV8RINr2dEhOEvP0g9vf8BMzgvw=,tag:U76viHd/iNSZLfwCEwWLwg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:RsEriaA=,iv:kOKwGi8/nktQA8Fb3wVmZ8zIMXdAPbfm1RbuFDJdEfQ=,tag:0J7wFtm6He5RAfwe8GIx6g==,type:str]
+                description: ENC[AES256_GCM,data:ySf4UTnACPitRtF3zSuiYDWK2TiEMOcjFtMnjhSpmGQCp3D3LGFmBl2e2GgqTkAEiSL1MPjSwrb+tIdN2tZmX5TeNHRtivIBItUqRTZVN8HRjzJyj6yPeCK3jsOUGtcBJqZ/h/Y6v0bTihKk/7GwlsgWlk/pQ9cHfoKEwZMR2GqR/Fp9SggY9iXIqVbbs+Xh345YD9hJ3pL3pIIkfDpsrRd5knRPV5lWN7bU8mRMlo5d2a9b0wV9O2r7KFPthCmTDnqj7B7BWQ/GD2oJ38G8MmDPyhcydJnaH8NwQ2x5BXD5m5o75GP7bOk1Yc0MdlRBzYQ5du7UjLGdOGfAABnIu5lBIUF6tRfRPPxD2w7H13efxcC/UkLCtxDJOYPe39HZBd+H86vKSQEv5Zm7vLQxXAr5cqqYqloc1a7Q87FCuYjvdiW/RHOqXzSxSJEvgXi8,iv:u41y+uuYgXNOgIxvzK3I5BphcxA/sngjEM3pq9cPV1A=,tag:GvyzJg1HX+Mv7S+IETH0vw==,type:str]
+                status: ENC[AES256_GCM,data:ZZrN966RudScZbs=,iv:KjrGwUP+Wc/MOcowqIycMkgMl+89FZVVxsMGZce9jyM=,tag:yxYotRgToeiPHZ6186dI8A==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:h/tMJig8jLEmqk//eiY=,iv:X4sWxH1/4re3yvDP0G2Lkikbj3dyXK7o3Cw3T+mjEho=,tag:y2fCPtwu3w3KbrJA5H4FSg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:53NbOBQ=,iv:8rbtAuAaNgA3Y9etHiXJkhI6y7sgF6U0sCru5iZBtu4=,tag:kd9hsRq7vuWqA0dgJFJyWg==,type:str]
+                description: ENC[AES256_GCM,data:UMVthVuiOLaOnBNNcR9jY0NNLXh1I90i8IT2jiYXjE6aMMXmbH17YDRbYrgMqyIidi+G+3iiygJg2q12t4Hdkv4ZTvIy4l7j2rNL24qnz/xXpc9JWX9V7A9TMlvPGFezAoGs15UwW5owz3cknNOvDbZW7IswQ4HUNAA9xUaPm49fCEzhrWbJMZVoJWO9DhrBYAb7okCYYwOUqHUTUIP0OotAzrLTl/UJxaUhFxBOzQmF7vyTi390qABWiPpifWdoJOcX7cCZzM1YVSfN5VCp6Coyz/lXHeLkybtWCMFPsFhdHunkibzu24QVmUXaZrUMlfroyYLGB2jHfOg9stZWJ9YvfZC4TQc64xXARe3Ontb59jqxl2TPWCDg/n0LW4Cqn834txNVNF4VMj3yyjt4j+iZaUnuSz2xIBmSvijshfXUk0lsEmks+mqRlBKpiMgtr3Fuot59b1PTBr/yLF6miyYqQbGkrAIS9MfWGvGAvKaxfmZopMnBwlkQMWdf/OhgzpmmuVdPeCzA4zvMsvwreYCiOhC1WoSknT7Z7Q+7tF9LkJ7nx6EudeVEdpjKFGY7+Kpf6f34Q+Fzt6+cq+S1B9I8cSvG+LirE8lAInRO8eOexH6/QN+l/mFpT5WuMp17lzsIteBWC+AohRSDuZhXZhPGXdBW/8r/vLBM1CVOSOiblVBIMu7aDxDA4t4EZfR7qkO7nLj6WyKIn/T3gD+txTsIEBAW23IgY+hubMx8LksdK9jz1lZkaALdwklee5PKgEkTAMSWwYbL7Bi+zw2v8jmjBzalT9k40Fxcunt9gKRcL0fP8/2Uve2UHMnLIJPKPi/a98ehWFzyKabKCh8CdORarxD2R4IdQZ/lKmcJwv9DvQ==,iv:TT5suCROGm4NP4Y4cHDFly6+XXpJX+BBUzjq78B6AhU=,tag:koqXyXhfPbUvP1ZIN7XARA==,type:str]
+                status: ENC[AES256_GCM,data:UCgXEznC6I97g80=,iv:p6V/sLOyMAhIl3HWFvzmyMWErY06Ai2YgQS1TkW0qdo=,tag:kPp2Wk4kJG5LBOfOUvY+Uw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:d8saaXpMpZgeIJK9NbMpfLv1AklI7JCpPQ==,iv:wfgs6oCZWfgDhaPYGO0rgBxl1DWqibSkLYubE3hc3OY=,tag:s1ez48DZ4ddGqG9iyRrDbA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:UkYu9H4=,iv:asLhzAIHSZ0irrcc0wmSDIUjZhOCJx0BVFtrrr+pjLQ=,tag:3kzLo9iqCAIj1tw2TzL98A==,type:str]
+                description: ENC[AES256_GCM,data:5QdDMx9gxmJlugU+h2GoFjlvD35qan+gfkm5uadMdt4LE1Zp7hUVThDMD96XT9iIrLLr3tBjfjE0zVFPdP+veEjVRVMNgbrsNxH5E0+ALAjk8Zgo9bDBwmFMRKbf2Rn/DF4V0T7CvOM1zNfFxNrL2maFxCP0hKTfydTnOkXfehh3Czk0yt4qu6ISgNCCpklU6U6xrDyLo8Unp2M27tLE8gTvCIWZMTr9ObeshfXGoRdVm1n3RFNxuKbc6MAfX01cLPJOTEr/v+PNxYBsVTW2n3lKoK6cV2v0TQP/SJPP,iv:7Rik84NuA02vuEmchj892dUAOIRZ2/XzoTf9gFMhsZ0=,tag:d2slMa12zAOaebBtz1LNzw==,type:str]
+                status: ENC[AES256_GCM,data:axC8pHgYQ82OTqY=,iv:kiaL9qUt1K7lP3k9wBYlCv8qoWL6ZXSZ4vpPk9rcdOo=,tag:OIQSk6ppuOqWkhEIlwjGJg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:aOTm6/NA3ds+I2HG8f2vnt/2GYzAtb4SAjE=,iv:FeGGNCAjPhsBFJlv22VZ4+aNKIAR0/vottpNJ/kc5kg=,tag:7DdX7uwRQ8bFGu0qWgkbiw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:QxvCKOQ=,iv:Mse64ZRLPAkaIywlSXDnsqJWa3Ejk9Y/EDxwyRekX30=,tag:qyPMj2S9HIZUFAgL5FAfmQ==,type:str]
+                description: ENC[AES256_GCM,data:sfb4jt9r0s//M5WvvKd4oxFXGWNqzZTP4ZFy21PC7HFKpk06Bg8qRknpRH3G+oH1TGewEgt98be17mfDARhrJ6ImASrNZAeVMUcnhbG/BRoudY+EZ1FmfWFOOmPPoc9+jCrBcMuHadEsCxaPvf/TARnUQ3p0n0NgD6Su8FDE2DbSe9ce9cFVzrG+MEEzq+ZWslHkybpdnAd5XmNxnQJHg+YN02gYkcPkWC9fNkLDIsLjyxeUlESZwIiIfDzepKFUtSmda14s64vb,iv:aoULnThH2+SrS84PGd3glSWXhoVAFl4B1xYsgl2jFnA=,tag:p8Cmnmo+s27ieRM99vKgrA==,type:str]
+                status: ENC[AES256_GCM,data:2E+kLkGgyJocdAQ=,iv:BY5TgKT1EA35y2DhxOLphoBr0b7bGc5wrS7qoFapnFA=,tag:HQuiSaMNcD3iYpjZEfQa9A==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:Hfvw4qCcQrvYRZmrVjj5dcU4lGWqJg==,iv:vaQGMLjAPXm7CHwGljfkQMVjjPQedp4on3YhQvPhNbI=,tag:IQBCEjTeuhZnxRrYZeWPaA==,type:str]
+        description: ENC[AES256_GCM,data:dZQ3uymg01CBQPmhwx0vxmGvumkY6bXPbQGEaoQSKgqfdYpUSQNFABQnz9ziTyT7EETVk6bn6zLmBzqSqzeFpzypxZATLpDPRjZKACI97w+d7MIZKWfzqJckrJLAh0Bvy3nIedM9Uopcfs5SqVyQmvf5VbFbbiF1tPrEGiUYs/N6WUUjlyJzT0LBKqcuvN0IDb4c1TnyUapr0VC9JCAZpicVNpukCrr2A1MorRAd/cAQ+vvu9aMLRAZixWNpKZ3+kJurqquQ+wuYRKUTCRGvmfQ6sMnGcQs6e/IM4Csvj5eSxysGbjuCTHtiouY=,iv:cc5TRJHKaOCpsrh7KbTumVN5jM+wZ2ROukyivCAgH3k=,tag:+m9w5rHa89Ppr83MeCWaLA==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:1/thdprTuA==,iv:igNu36ZuTS5VD1JCNvrZYhboIBQw69EfmhgIjofSR9I=,tag:wgToR984z2qHmuaT/obIkw==,type:int]
+            probability: ENC[AES256_GCM,data:V2rbKQ==,iv:+yxv5/u9WNI3d5OrAOzZ1TkrJD1YkoE6M/xpYHaXQII=,tag:4Ha42tVioxO/tt1N2VrIrQ==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:PyK6ingU4zQ=,iv:FnqwmNRQ9XnGRmzjRwnoDqXUj7VS1EsdWKJ5CzfXCow=,tag:tt2gUeHSHYHL2JJ/Wblrqw==,type:int]
+            probability: ENC[AES256_GCM,data:6xY/,iv:4URb6vTT/AwHomATbG285PK8rNrs+L/ryVATfqvoBNQ=,tag:+UJOWnEZvY8/xnvNswvtDA==,type:float]
+        threatActors:
+            - ENC[AES256_GCM,data:l5+oWiKZHTxNBg==,iv:2E4QSxhsz9yJcH+C9CzqY24G0lkWmAH6QUthnTy6Vq4=,tag:e8Siv0hVc5b3Z7S6gbdxmA==,type:str]
+            - ENC[AES256_GCM,data:K3flzPPfBe1wIAI7fBXsq7E=,iv:/hlXUPiviPJLdTbKF1/Jy4qMb1gbODkvyClvHcv7M5g=,tag:VTsg1ALOTO7lMoV56hpqNw==,type:str]
+            - ENC[AES256_GCM,data:mdmC/JuXSw==,iv:pPl102F2MPhVaIx2RgFsqfC2uWoFoCiymAwNe7O5PHc=,tag:UzIXu+U79ofaGJvrqL8eGQ==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:vV0TDD4PgXLthZ3ncnw9qerXgc3U6Qk2,iv:EQhTsPoOrU/3SxEny6a4Z+C5FZZWzAR547ekZ7POUvc=,tag:sWa6ndD2Z2G7baAOAPgSeQ==,type:str]
+      title: ENC[AES256_GCM,data:vaKtLz09XioVQOLihtUrtB6MkbKUfl+0od25naFLffHFhw2yY8MkfG6Ee4QZOxU5CF2/GHNW5qtF984P1iXk/8YjFU/TWfz/pcg3KA9PGIgQxygBlvlR6R5vV2qnmWVNlU1Jb+SDXBL48A==,iv:E4/ugPbLxx2pMYhTEX5Jqxl2abkCqOLUeHNthFXobnU=,tag:PfSZcEZgT6WO1KcGvMUa4Q==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:fcqLFaY=,iv:PNxYl4HXvCg5F806tCNST4Gc3XLRirmOneYtnye7EYs=,tag:XyzY+QIHsSVLUZi2DDERIg==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:ZUY9+ww=,iv:R71xb1EeptVKoXsdOATwm0W4mSLTsBjxRnrexHmqjZs=,tag:Frdn+7w0tw4Rs9eLjhKz0w==,type:str]
+                description: ENC[AES256_GCM,data:1KbO4vH2YcnNqI+WkDEKWgZ8Ks3+xGkJXa1AFUuzuEAi9gC4f34/3YkyKbk8+d8OHQ+wSbi7A+M/o5vjneVYLlVEo9CROflhLJLoSpmooO+xafb3ArzeVVpq6Do0HYrzbMb0ZDFvf3n7KrvhuLfo2De1uqnUVuoRJQaycpkQ5i71mKkBsxwSJYFxPeoUKCG4hDqTH97G7IbqHzT1lf8doyFSME1JM/zYmWSegXbBJkkc6H56pEAYWtY4OIx6B+Nkk2eeuCkTnRakhhJGrUJY6fELjHhFBJxwD02cNBgrKdvl2k3avS9oNg5gfK6ks7w5MAadp4WKUVsUsOoH1AH5m3Y/5vCQR8+SQ3VHDeP7bXOE2sRYFW38rXSPFWEQNNSF5v0KerR4uV7mk6f1UTh50YH+4vi9i7adjI1HfchZRoD9E/cGRHzane6B7wIT6iqR8YQu8YTYuS31A9+H/eImJ0ipdf5svndt7zL7n1JDf9gcHh9MxbU7X2UePwijqjYqypcp4xVtD3KHBH7txvD4CIjxdosOiakhTU/2StI7IXWxt1zera13S6R2EiqHv8rB/cbBivB8ge2LSYRZjY/EmV4/eVD8+LA1k2mMR5TJmF7oLqszmg6vlAkaEM5AKEpY5l1eOG3m9vajfssC1pz+0rgK09jgRboCw7Ae5L70oE2U,iv:9zSHIy7S9NJQqODpDNmob84AcD2jQ7bKFKyfM2+T2J0=,tag:w041wWfJB+vPspF9D77ZBQ==,type:str]
+                status: ENC[AES256_GCM,data:tI0HR5eaYvJj3qY=,iv:xu9IGhFi4VWm0KJQsiER7BOf3tcutdZhJomO520Ac8w=,tag:3wQas8FyEV9vAyAz91X9Xw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:i38g/YpNWhxg8nWL8wkCo/Utm4z3SAxkNlE=,iv:ZpbQCc2bI/Zk+Y2P7VTSsSH2lTOr3dLdyz/MY3SVA+U=,tag:zAUeJ9eqdy8WO6CCEyUSzw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Krk5SQU=,iv:hHvleOVqBTTgzs1T5cjq0jLJmF9QPOr36EV/y+Ff9gU=,tag:2SKJXz7k4Q/89M6DeaVU2A==,type:str]
+                description: ENC[AES256_GCM,data:oeX2mQp7YQJQwI4PoJLww7fOOWIPbE8YOwtN4PjQszDYhxwC5tnSrBeMkLVqFaNBt5AG+hxclrrjZTWcWKAJzLlO/VNLYqOZtihDWgWoSO8tcErPKZtrBjBpEfZpVfORjgHk5WePXXBjgU9WTePVNLe/FBIwMJ1IkDvJgrtP58REVX6XaJzQUiJsRcvmiqWmMtxqrW3Nm941806BoQ1+L9/zgYkuWJBMApr4FKZa/NGHeC7178mpzY2dwwGWYnE4KoKUyuBDRQ==,iv:lMBn2tz2oJH7CC81bZZKnu/yTNr9p9KjvGd4fmU9QeQ=,tag:bXO2J+8EULeJx2Svsnl1Dg==,type:str]
+                status: ENC[AES256_GCM,data:+QWA+aucKqJVPbo=,iv:qkF3gomKMTCaE8YlfVZ6ehwYkGVAeBykav3hOmf63DQ=,tag:NJ9TpEIKO/aejf9N7NWAQw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:uVkc9Jeqx6iNFYFx6KSuoNU=,iv:v3xMgIBbFqZ3r1rFgShBgxLta6ZPACgD+lCkdA5SRcc=,tag:00M/KJtWCCNCpX1KAMi5UQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:tqTTD34=,iv:AUp9JtDWH3gipwkuzUqkJNy5cNbsDE9f9xwW926suCU=,tag:sEU2LTd00BUcHeyxaW/OCA==,type:str]
+                description: ENC[AES256_GCM,data:ZnFwsB2jdFqZA8hXEEcL1FOxHzPBwdCf4fMnpduFrl9ZU5gBlKXqQwsnM3M3AlaQE+l6aHfyYeN4JhCTNuvx5POaISRz7nWpQRODT8I8C9LB6ZwU6B0Cqr8ngRIl8w7CMHBrwxkHymy0hiDfLxKQAQRpZOXvX1e7XPwvxEqRDQqScJ7fwJqHvBIlypGIgk+5vhEIxZMIU3SqIXUiG1I9Eb4VQUjhpd/yuJsclkp4JgYMSKH/C0wbXggG3ctAp6iUVcbwnBL+a2OiZ+m+nTNOqkLER25bzyPSLYTgC4Z64FFvt2AoS5kZ41y1coGkDHj9XhsylJNTpX2okm7cf5UtZrtgejyMnERyQb7ICDsjL40YhTemASJEtlzCHzPCEWAOzKp/mmAeJG8hop1SzD/tbLGztw+gGAMvvv7+91VYfE9ViVn16TvSNWjXY52xmbMlmqBFCOgGV9NHNgzEf0YproNXysc5dQkOv1jHL8jOSmgwSssDlo6wnZgQtZWgRays/FdlY8qIPV1BKfkGMkj3w8i2wZJUFwGibd2glwSKo3RwBw==,iv:1kxETYtrk7reWIqAJjZfQhDsb9zdrc6C7FOjvRvvcB4=,tag:oY1qAH14qwT7anvJuFQrhA==,type:str]
+                status: ENC[AES256_GCM,data:8cK6JwSKixVYDb4=,iv:2uBLq2Eta8DFdXIfqClY6iapIe/m4IFIuJOw98ivCrA=,tag:KjmhSQOsTw/7zn6eBYSNfg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:aZW1lOM1pJ8d0kvTzsulp4PDUkRsDMR/O4c=,iv:qzLPEfZ5yXDYxRAzsn3YtHfO4i0wnkwPI/ozY4NDX7E=,tag:ad0mI96TIyKQl+zjPAj+pA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:eR+YhMY=,iv:ZIG4FykNeylq1vmTZyzDGJdoqiU5bw6myRHNN16VEtA=,tag:NXX9ExbkPU3qbojFo8YQTA==,type:str]
+                description: ENC[AES256_GCM,data:jFkYaD5LlwDFh8ozK52D1OQttMLVUQUAt4DVFAIkBSUz0tI7h1EfekOBRjjhYqIW9BEuL1vifX7c9u29dbf2PII49jaLDgLSAcP4soqil89khTGmIMouQUg5xY4xX5He/CtBJibAbAhLGTCVwKYl2EY8K6kmrSyMp11fZ1adR8ORKZCsT+yMDZ+sIdiT0p+ieaGJCujOqL3EDJvW3M8r2gVzXs5ro+9Bq6D2Iz51sp/AM13L8fcle6KS0cKpstI/8YMqnJsiMhzHR1RIMy0o9yhkZwCm5HgQqoWhL7K2+sErYPt/cPcMYG3MCo3KlwrWfEu10h+vC39o0vZ3HGdy5PaJwuS9NQ6btIQ/dBlktIfYJVoc9eCGByEKXOlFSNIiBSazpCN+J1BWm9NfStXnmF0/t7j4AdTzW12raxL9d5JVDJfJR1scghkXHWeszsEzkbGLTtNFBxhHvR3nVefH0Cu1TKsKZE0gxG/04/aTGYr7XyFdQp4lUjzerEjOPBGRoLhdDIatDoYbg48YwI9fa5C+XL1KnBImfUgbo5BcjOuxgb0gaxusCBMtoW7WGk90xEeiO9FXOhdlajd9G1PY18DvsSBZE23tdJBRTKuLcij5Xi5yAkLwjRdzQH7aC+x+zKDra0xZXYbctAcIzi8vNdIbJzXZq97eLt+BAgvJYN0RUiJZ7s1ubnT2smY7Fj135mPS2SduXNdFFhxPN7vrUMItQedtge1FYFw0zkPZuTk9xAE+PNuI6zPQAyzoN9T+91dziYXC1RTrLRfaOrCcHm4Qz7MgGtY+PQ7mA1kkH0O+1SoA3PegSej8PUXNzLy9NpKPgs3o7oyiIBHc83+3C4M+7Wp/VabIhRbv8Q/iZCfxcMsq1QLaW3Z1tK9QXwIDfvPJS4ntQ5nAkEP78F/OvGrkRHNULx9xzp/W8GQ83TSL/wDzi1H3hpLh22S29+ulX/re5bCT/ZNOj2ELc+/BV+naL9yu0UYgbNzuVyrH4/FfS4gbZyoze+GuXif60KCusvNs6Ocyr5KBIfh24UEJCBkB0tvvfGNjod2jBq3lzD7jPLsJVqmER5+TPoA0M/nmmyWoMvU9bD+yy+Q4chTwbSuOs/nKTe3KSr9BmxAlrdZgolrUmdwiWJf7KxDrJYEIaB/s5q1MVy7YjLvoLvdsOIf1r2wSb9wdqgan9NV9/PMH,iv:Dz0CGap9gIhcGe8ZsY1psheJl6xfkICXtwgIHk9EMDM=,tag:69n7u59OAQSuYceymKXD0w==,type:str]
+                status: ENC[AES256_GCM,data:edRSMx2qGbuLQsU=,iv:u9U8rI2xythiJIIVrx7DThQ8Z0aAYsWj8i1WAUXsEL8=,tag:U0dL0aRAja2sLlK1Ra53fQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:lNC2TK0Tekr9np9eFve5onDAVQ==,iv:tkCER4j8JVh063qKHQJcaRUphBlr4Fu+MvW5G3LzKPo=,tag:6c18mzb833NVSUvci3rxFQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:x9G5KIU=,iv:qwZMg1oQPoHTknq1lnCTJ5qPNmNfueid5mWB+euEbeo=,tag:79BARofGei3XSD+K+Lb8VQ==,type:str]
+                description: ENC[AES256_GCM,data:7r6VY/snQlNPZ0HPDe+Z9ognK2Z+a94AeXivoZWPiJlfVL1oj/W+Trb9NEOE0i9lVyF6n+xoo9q/lJZzgAvonIpVE5RjRmNx0OlDJwURUUskc/AtjC6XOtsZQkCVKKdlex+3fgPkeEDtgrQGDFJ1bS51mp6QDQWSwaQZ4OwBYLzeflIMGs7Q33NycM14Pqx9C/B4/DWCb1dosHqmZayXbnPA2MEe8uD7B5XK8Nebu/Xd/bjnlwpD9vBzTLBTAsj7v6Umf5ZaRvSksi4N8hQNUc9P0DbgstrgbxzupfP352RZTVMtmIrKZijiZkmTdz1PfD8hGPBih8ccLL9X+cFPNMZaprWbK4QNxZgif3SNQH6FcxJiTC9zIQnCx9w9fqcL1H0a5afd22eZ2Hhw3jIzwQeiR1r21XB3NPiaJ+2BQTc7xPlciLg=,iv:WFY/fez1dGDEZQpxTp0LH2ozIjSsx2L2b5tDpAcCXsU=,tag:2WwxPspHi8E5CilZ57noWw==,type:str]
+                status: ENC[AES256_GCM,data:DL6abF5lI2pq7r8=,iv:EVtDG7NP1JHFHHisfy2gl5qK7kcqlaRLq0eBZT1/s0o=,tag:6f3UNg8JOijYY9YyKaXlNQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:PNYgXnoQoebBYwhzZexu58r/m4UX,iv:rTBj590L7IkFr5LJ7nu54U9IBUFRngX7mZ4iCy3O8MA=,tag:hKOq5L7c35DeY1HMoxJRQw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:DZ1MVKE=,iv:ayvXIKxCXcA3QNcyT4VM19yFtrD0R2Bih35mNF6KuwQ=,tag:ilGp8mNm5Bt1xbSrOiyTHw==,type:str]
+                description: ENC[AES256_GCM,data:adVu5piuRLJG2/c5boW9TE4wLHF5uhpJjPlv+OcQH8stNbDU6JQpCh7fVaUlg4JfUGLPzkgdrK11nBOMZoKL8MctYTzPQx37EyV6i6AtO0UJs9ugh9MpehOjSfJMiXPFT1WUx3U7IQuKRbvz/HpKO2oXcDE7PGgeQ4tUPldGoFHWcteZxtyJA3LlCg2ni4951lCH1ZtTiZr1tzmxPyAxz2Mcy2GeVrp64NZDwS81TyjiQOj/b/Ro0fGapUUF4JU1JhnezX3jF/BylqYioQ==,iv:wVn1YjUVhUfAHQSKIGSEefz69v6ToHPzEu9IbMlx+mI=,tag:2PA+lWnJaR1Vvh7gn3HRQg==,type:str]
+                status: ENC[AES256_GCM,data:xSNcN3nxSjBCP8w=,iv:Tkq7042cdnRQALLK81Wxt8a0zVpaRYXOxGh8zUsfNGY=,tag:WPvfXDN5e28puj+O1y98Sg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:mUJx97aL/qytHNZPwFCfP4qMNpdj/tu8Awp8LXC+,iv:JrKUD6+1rn+cFNB93egm2WEwO26U26DnLXetoL56NQU=,tag:JZg1pQcDM2qtrBmYbyUzkQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:IfyQ7v8=,iv:o4qnSfCnC6HtrFY5hskgZCQzoq450mVh+IGlbiOeR/8=,tag:HCHktRN8qbImc+EJGZRbHw==,type:str]
+                description: ENC[AES256_GCM,data:qFG74WfcieWz+xrPkPfNZKJBBzDdM6CjwslAJLEECIn8EfDCimyuPOaA33P3TWn6TPVAjYbZs2WNO7HRnd42J0gGkPx12WRiocgFkJq8o5izrbyWbu/5dey5mqqUAd5ETH/w8oc0Kfd36swdLVNBTyICUcIQDCrIPX566oc+2hsRwNsMxRwBdUEhZyeermWwfimXSsQiqDuC3Hfadbsq2dROnok9GRTdfzRwWb+Z41wwRafhprJewbNagJFcnWWCpg6OImPSDB9b4Qoe/o9WGTzekkROdkHxIyKX9sLnAE7J5vLm0BfxHKCklBW5Z4m8C8EVBbb3Xn6852ZwvI3ESAAR0A02OKbhWC39kCY8WiieXTyYmOHActfm/UWahMV9r6cZ19G9k/nQM/N9Yu1UDD8D8BWAp6HK/37xWtNBebUw+Z97n/5QsPiGBYTmvKt3tJyFJU4oCp5QQv0CwnVsGpcX/86bX3f9G5qQQ8lc8ja+nLYLwR/yUllws2waXyaAjBb8LNYOJ4UijKup+KGIOwr5mzaBD9lK33mbL3Eor38veIgTACA2/eVhM1DH7muKEOY+FnTNI5YGya7gKZ+RowR6OydrnCcrb8is2bVGtZB60bGHCHRnus/kSupkitbkbBXAc0wl2RaG/gYQZZuyUP6cKheDZ7CmA5mv2VzfE3JhHk8DwYyKLCEMhcnSI1XR8YwFqRUpBJVzzb5rALRoqpqXalccINIzL4h9U9ByoB7ZvXDKEaftnEXzLIpUSPF0OdR7GJNpxegiQK/ARFJOkNLmzmzzZZFLxjJYMTsuthkCPj10WoNf7h9S49UVoq4+nemYlW63XEazHlaM4WOtJqGrQJKu1MOKgHlEKzKUyhQyesa8YRjG+VwYA2Dr9BI8qfwPe44640+m+KSVdOpJsM2gdLzDtuoVSeVLnz1ldjt5bp4ODfF4hleUS4Oj64ZJS0lswK/gAaW+fS+BPDthoKRQQp1LPSqijY4Q/94kh6xyDGxaAzW4uKt5chdY88+E8AlHUv/5pchL0rMgS3Yi8jVYLq/jkE5kVYhTi1pFJeMQgJ9Le71Q2Bi+EXgKWeqgR/fj3qmy68qIgV/m2QcLGKEK3bzB9WcBcSeiwzv0oD4LNssg7v/xxnvld7Ikni7yIzs68SdhFr/5S4FAml0C6QXOSGnu9ntELpEY8W9RkODet3aaZTLr4myusQj1cERnT+D/kESGdkIYsWuF9l6itVmtdxNN1tNuvCXcATtD8LgBh64ln6Aco5Y5lmw1jjzses+6WemNkAFaRZgohD5wn2ihvSEbGicpBBicRJn9lfvzcmmWIAfiivj0C0VTZnRiLkObW9Tt,iv:VrhHMVquQvwYZd2MjPIehTI5mRpX3Bu5GLii/zyMbrs=,tag:AYUHaViAzgUS/rvo+yz5tw==,type:str]
+                status: ENC[AES256_GCM,data:tCP9Pz+K7sbypYM=,iv:Y2em7i+HocDhUWAl9ZD12DmL+iwIATvhPeeVQPZFxgM=,tag:QOgOF5HZEn52VJd2or9B2w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:DIU+wBGwuwEVWUjDihXxkPu3pEYv8MgYOwX8,iv:0zaOn0HNAYyQsiOsSnMjCUzkoUk657Q0Ew2pU/S/7yU=,tag:W+ubNsOrXOjPeRY9SFU/6A==,type:str]
+        description: ENC[AES256_GCM,data:9QXZjHIkpxoZ+30IOpV7q3Hw6dPcnoDaLZ8shW8CNShGBKCM8lP25jiB8EaE2tFdz5DQZMAZsyXsqwkwo8oQWN8eqn28DTnFUTJrs9oj3F3UehIZaFw+dM4l22EtGDqc4F06xDqjULL3ZC1FILqlyAiS+HeK4vM+d5Lw8HmcJzUsP7MYedH8EGiJLNa+ydPudIWC576n0vbFjp2KJSfr8toI8ozjrQoFPtq7k0LEvitZs0p08nf8tcEy0ssCj7rsvyr8rFlfuMo814IeDp5IHbz3IqKpUhjdELSpT6kTxTf93l5B579KnePlR6a/mLjCh+IM0xg=,iv:tEi1MqOIP+YiWA41yNMeoXaZU1zYpCmkodvHrubprzs=,tag:ZTSukljZxeQoZjzIs+Tuvg==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:+eRqiZRhvQ==,iv:pxVuGKTYvcvva03r4nMofS1zyksXcnV+ysIb4U0/iYM=,tag:AWbcMEvj/YBDNZ12cYPDaw==,type:int]
+            probability: ENC[AES256_GCM,data:Kt2j/w==,iv:zwQrAm3UFoWJUNveR2cBvtUC0C+sQCzFEaIpIDcEXIk=,tag:OoV2WlCn4VK/Yu9ytFyQRg==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:pCpAqp2Nt+U=,iv:0eT4zXc9EfrPwONxYv54FvQoqERhTKOaDYCamHfJDdU=,tag:xt7y6VyFuc43Z64hULHQ6g==,type:int]
+            probability: ENC[AES256_GCM,data:0Q==,iv:Emiud6SJ/MOCp2BGn3EMpjEEaEiJKVa6hGEO4zmX+ho=,tag:yaob1yMZ+0hPVJfu8aDlWA==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:wauGZxgqCWsyRA==,iv:tbHNPYXlimDYaKx7jEDCNoq8AKosA1silD2WhQdD77g=,tag:6ruLZfpfn+RkQR8wqVINpA==,type:str]
+            - ENC[AES256_GCM,data:R8BBLJdm4A==,iv:UFcKhtVs718TgdcBHRBhiB6w7GROD1UtUvcYHjprFyg=,tag:qtnCSipea6N3ctJVKuma4A==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:c3UGAsDQQ8D9LfMnyA==,iv:zr4PR+lKV+apk5/ouvxg/6Yc1LSwTpbYzBsaszEeyC4=,tag:sVr8wb5rBlOX4KkoN+Hp/Q==,type:str]
+            - ENC[AES256_GCM,data:fIx8mofl4Ouxje4wNsMFuA==,iv:aMGiDQGZzsLmp5tV2VT7pPVPWrfKoWO0YbwBGY5zSzs=,tag:1Nosfl3Qn5BxGBhezHMDkA==,type:str]
+      title: ENC[AES256_GCM,data:MArxk7ntDhtt85/LTaASSWO2ZmVDR3NEQyzfXjB/87z4M3PZaZtIm9lOuPBCbQyrnFTDZSmNYzX40WlTz0AYsMzz7FCzsAXsc8uRX/8p42rg,iv:ncHoDK8yWA+b4And4DE4lHUk08Ny8K7mjL5O0WsDCbo=,tag:F+yuMekRDxdyNJyJXOMZqQ==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:Ck21Y54=,iv:Hm6zn7hvIgvYNFR3O92aE75xFOwemsfyupEaNkrAyGY=,tag:j7j/q+TuvHu7BBISBBWi5A==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:O0XF2VU=,iv:Uq4dPNBx21TcBaRFPzhNeRifqt/KvL2nNEgK8nhD3T4=,tag:FiYsUjtStMjH6cTwrtBdEQ==,type:str]
+                description: ENC[AES256_GCM,data:1HwaYOavW4AfVB5npqKDiqXHAq5NURQI+g4P13rt9b7hO7Udbq3eAS4KP4BHiTlMYX12NQ/8Yq1yUFwORevMFkfIrF9BIqhgP1zjZUpg7Kb4j9d26+F+mKZlT6wpLUwyO60V+C1d7rfxRWtfieIbPTkd836R3rXawtFB7i5iWWnLE9b7jvN7FJ1CpPnuqn0DTJW715dg5hokM0OHmNH+YqJDhY3GdvjGOHtal3up0f4CW/UQhizJYBFWvEqxQdnltn9h6qZGJGrWOtlmKgch2LYpnow/nSAa+VAqH4BdcpN2uAVM3+NiXmwYqUJM21lM1bhNU5MPzweSDEu773fvI1jsjbdWR3mfn/D3sbwj5O1qILQ6cQbbliHhhhTo0C3F1+bS9LHdSg0ZLqTXWg/3nE1Z8q8AUh7Uw9yFteMpdt9ZGAjjogMiQOIcOBl/rP8zpVrYt/UpyyWZ4MTJvGlDRV6OqzVEJPbe3A8tozFFvBjcBvwZBDyUZqtaEovQ3gTjJ8Bq9wsFmi4gH7IzkVU6xSPUIbmKCh2ywlA5xMUatV2EeYqq4UWYz3XNQlWnq1DR00frs4zf9rIbvlS9XmGwbpDvtHyxKFdftUbGQOLnshMYAg1p0N/3hXJ1WyUOXcEKJhyJa1bfqi7AJhVsZ9sQHQyIrN5PNwiwW4mYtWe7rEVkpntaMeJQoR3QY4TOXrZfvY1NFXRR193iFHp23Bs0QpY22/tcBnj6A7WDxT0ArlTbtBKGZgrHBVJwhLR/gYY46MpRGBcMP1mcgAlMtXipcrYxauhtUw9/5ruC8NeVmIWmVHUoblAQMh21sVT1W+uhIce9l7kto81evOvQ0XNb0fEM9QrhNmka1PooWR9gQ+UfO/lFA7t6AGaU0qfRw87xZ0kzoO8zlu/cOokQW/2Lxm5YXVA=,iv:r4mPjzbIlvsj+My4WNl011YZHPm8B2P8LNy0/99hQIs=,tag:CsKUpA+wfgEfQHu+2jHRmg==,type:str]
+                status: ENC[AES256_GCM,data:dXZhkNd6m5BF21w=,iv:+fUEEK8KtLXX90vhfrduwCnP1Ev/FFLnMPRQry2MlJg=,tag:DEkCKGCXVxiqeRxsvpPjtA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:VMI+LMCvlxv83vU6f/OZy0x86+mBgPLB1CoG,iv:wFUTAFMFQDAPQJIat1tREf/OieXTHqzLfqq7lRqsex8=,tag:V9KnDtDHkSY03Iiif6yBAQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:3XVr8mQ=,iv:MhBigx7wW2YBahNVBPtdmZNLoj2aok/pTjvzrkX2ijA=,tag:8R9/hIRkrUbMxoovPTvLwA==,type:str]
+                description: ENC[AES256_GCM,data:Sd0XkmpCklLkXXuxnvldSrciSJ0QQRL5zLVmSbdhLswH7IyB+PQLSyFmVPFS45jSSoIwGmLlBgI501yjdsNC/o8FZos2bxslGtOCze+rlbqsIoU8WCyYgBvDWpa8wBM1rb2b8KcTCmxfOg2Ts8JBsiTDxUM/cPb/EQaFetMr6G4SrTLpJB7yYFpMGmDrjQzeIJnXuHbYUrg53k5O4a+Uxu2KYiJHeSULIBKfcf/7BdmK2BjnWD62mrpUpK292tohaUkfOjTHx4Bf8O0x+rP0e/MtlUCSWWA+UqpU818xaPshyl3aDfD7Ei+6I5TwstQX3C783xUkLOgAjWh+bP2GgNEHTPR2Y2y8ChU2VGnORskY0P6ykeTUFMsL1/6hbj84J0s/Tpe6+Sod+fNmBL0haD0fqOYGjdeUpD1L5XEEBQwzGBmxvVYKhhleeBau664cgCjayjEjMB9c5WcrUfY3R0kSXR2HyNcT+O6xLw2TI5Wp9z6RX/39wXpQjiuiEjzu/SgcjNQzjWc3yhJHcE9j3BMTtDAE5AcgIAzlvnJSRdEFE2C+mzIgM/HIyLmPsKPJmT55X9c54zb/mOK4hc4HgQK8fv2bA7RoPDX3CJJ2385gvVtB3I6lRo1t6fDpH+cBrSzvfK+WVSjFPseuYeHb73F5Ea/3Cx15As3oVDzClPWzVrengNXXEDm3jUc+ynCjL0toBPkx3xj0h3NDQUNiDX/ADYcGFUSMAJpVsb/PgyA5hUmOg3OYw/0YLyWeE9rzYIL4pWf6eP5xUert369mW/1DtXf2jndQjYg64F7+dIuz1Wsc8Ux+nOCyBc0zavsaLJ+SmOQmnrrlgJ5OKSD9PzxZOp+v11i5CTLMUjAVzSqqHmZg7SNqNf4wlXSYGTBSG6UZtmVu9YkPQSfHgfR0cSfyXYLib9tt7/NafqE/jSdfAWsNHLk73KizDRLFG96OiJifYFQ7ueug1mis5Sz2ThxavwmyqTxcQDHuFWAQA0bLIXick3JnKPTblyQgrzt1SIYpLZZfFlq+Vp64ART5nEohEMRX2cK43uRVzx94cKE90u3QUOg7GuY+/Db4OYXR9pNrmPtYiCcAb8eIMMX47QKqFQF5g2bVVxBQEgviCyhQNw==,iv:lSMbz0266UNyqiQS4eYmniEqx2zGqc7GFcyaVdoS1Jc=,tag:zLxT6lKVjtfa/yW7ZGKUnw==,type:str]
+                status: ENC[AES256_GCM,data:crmLsYT0ea3B7n0=,iv:lbT234NhZ657S11y54oIZ5a4l+D2JyotmMaNHmRQ/lo=,tag:/OKpI7wEcCHBQk4FGOGl6g==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:AYZlL9r+8d99q1NMHkGicEIGWs5ra2ETZQ==,iv:+jiTn1id9rvDtOA+iEOdOKkmtq3NgeWBvceGjXX+51M=,tag:yAvai2NCWBiTke0zcA1X6g==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:aSb1yK0=,iv:rbbgIdN1rW2JfSzTLQJNTWwu/vP3RpFhLT0TZvZ8CtU=,tag:SWxWN0ObGOdxcvY+ts35vQ==,type:str]
+                description: ENC[AES256_GCM,data:dMFu8KAqM42eCrB9K5zoityu88ET8V8SBzN/WyRBKmw1+xIL5InDqWAlThdZE8kNlm4S74PtanlK0Q77MujI65ofedKKiBvN76Iq45O6dz/hhRhlvM8nvulkp/Uaka0uDAJD91DoQaCR12dTCECZNJIQas4/JdXTod5UBIMr3KiHNRBiD5sMsrHDDg971+QbkST/MdMZfNNtmfEHsJ+3EnVaM67CG9I0FJnTkhnBDBPoxiAHGNIcLVWmwHNr2cMMmJQFQihCum5L8GXhQWS/bKBRrjY+HVPB865SH5fcly9keXkiE+DliMUl1Lh8A8d2wofenL9CawAJORejidoYYKSkzXps51IdP7zLawybqSaRW2MEfXer002p50bhXO6I57gVIe2RVKdePNP9w5NmEke162dDFFbCqYipnjVJfcVRDs0+qkOrIOinKW6vsITUmBqTMSQd3QMVTm7JwFNvtaAW+mYUZsF7lAZXg23F8ET4azs40D/gpzC+phpCCFzJb6TtHhfZ+BSdlDojcZvXS0FnkVbsm9O77urf2VBVv4d6dpog0UK5iQ9eDjHy6VK6eDHeTPe126TCJCe6UqCEfVFuGmG45424FDqoVRwnk/FtCdhWGWkWAh2jpBDYcdGaA4mPQJw3JKbnBjMLmNcsbNnH9QdOO4w2+MaF8Wkk483BPeoU1hQFHvwy6J6rRy5ImuzUzn/+cx7XsPWqlTfvV/RlpibocJ8SfXAH9apw2Ym0jVfkDCtSc9icWKd93kCh9R28VY2jtkWQAtRRfk+4nTtlAO6LZE59SvloOTvfvOGH1WkKitMhN3SZzA9WuGSnwOer6vmItRbXHctG7pmAM3N38ZoeLJfuPmLaTxPJ0+gfErdhe3WIDOTLuPBL40D+f/RPnjXr8Sf8kHYFFKwaxZjkPeOIPqMrFRllmQBGSWxWJUO/gvLTsDJ0XZGirLzbLnmE1g9bigV1m/LY8eAxrU9ohMJy0MdP5DFaV9u3NCA64wfHjNaoOf9aL5u81ZQlWeQeaWkw51KLLuR7HnEnuWqXOUPaOADp6/8iwXHHWC4kjhHAQ6S+I7iLjvg1dIOB2OXOsX8NZAp/AB2ltUXQK8FXri3SKN2lMwZZ2geIS30+5dUoy+WN2nDDxXmY5cOSZUC0WhLaJKKbsIwH1AQD6joKO/6l1FeDdPc9kaFhjXCzfO9WbAO3YWYdEi86iOENW++capJQkpUX/e8CBwrAQ7ijv5QUYCcMD1OG0HxMc3AHYNqgEmaAnzeaG1+S6zX9w14CEVgy+4zUzrwbecBFjJar9NBYyf2OHPVhlKCU58FPq3aAkHYC+8Qed7tJvxdTwP4OWgdB,iv:tNAOJ0/yfBwCj+ehvq78mTEh5LyqaYS/P+OnlqFCYOs=,tag:wTZT5bsGB0tbX0GAT/vhbA==,type:str]
+                status: ENC[AES256_GCM,data:y50o3nxmwJ+gGvU=,iv:P2cNsU42kDoMvUvk5z7kI6vhCSWtESCXVjQh9PkcMmA=,tag:CuNlDUUGUgSrzBbD3UCynA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:zSds8mkO8gr19wiPxFeYLpkFkvw1UfnS3Q+r,iv:+L4qr1sllahH/I8O/uqUP4i0fQuXFL8q4ebQ0jTJkx4=,tag:LF3nh3Xgv4li9jpU6COcFQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:3vA8tsE=,iv:PCYX75ibXPgzovF6OlGKiX2qjVSMRKHWrOh1s3gy9+g=,tag:YTzkevT8mi1Ty4h956C3/w==,type:str]
+                description: ENC[AES256_GCM,data:mgDo5OrPVxHMZncvZBgntbSfiNVXBfZWcucZmXkm6ho0yB3vEaQsCpaeXi6te9trckti8wDRHGBwMI0H9GuElAXuLtO/zboWbA860Oz6n+X3GoJeioIPQxM2bpPObRkwX8/pV+sPQgN59pW7GL3zK2Bga+MlJCICVh4NnLFNhGpHm/aA0I1dpAN2TWc8hD+mVrtVFJyskXDwjRxBYZdHJqebG1B+xaN4ssk+gGmzauWc5AxH5Wg4wsSM7N+/pcSno+XEY1ff/RrPiMMBP6nLsDhjiaP2jUiVoFWbhOHE0y+ZedEJNJhSxPRf0ntCxcWMYR2n9A9RMw==,iv:iUlKK0dE5Hwk9B8wpvP9bF7vk9lGQZNkqxw9JLslJUk=,tag:3QTezwDl5p4OfcD1wf3ZSw==,type:str]
+                status: ENC[AES256_GCM,data:xNj38aksd4Wgo3Y=,iv:7cZAFMK5MVej3d5XSnIRA+BP/K7QvndxIanllUVWhQ8=,tag:O8RX/LmCacn8SWQKnD7eaQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:Cc6J12nHz7weVr78sBf/fx8fUsos,iv:b7200RD1iryu14WT/Y9sBdpZNiwoXQm4vMAYba42w+E=,tag:TwVux3gyMsub09dJ0ufq4A==,type:str]
+        description: ENC[AES256_GCM,data:lMR1bkcVnydXk86DvVO0jXfip5YZhhFguWL8sDEMPjohvT91VHs1U4/e5/yoe5AU7ZfvdBDON20zAsN/ud2opq9gM8wyR+STeUZgxwSKtGMoESDdFf7AVoCwWF6I8ZsbuSP1yQAP0mCGRU7p/bFlIisGPERA6FszrqFBnEBAW/MY10zwQbePVUUZ60HwtFNRkewyx+lxofPVTAKOa836ZFjcq9vjjh+MK1wRaiJz8DnZL3YTrOt9K8r1r32poyGUMxY3fnf//rz9tP7nZgcv1VprEfdmZPYmWKvP5mUHZu8kLTgbgN9ZWNrf,iv:C2Nzmn7Y8iAWR6hfStqJ+J4PcfJk6zGObVa/6fa+zBM=,tag:/BMbkTpOqWdk756IUCIvhA==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:Ceg58n903A==,iv:X2syJDho5aSMTU9wC0glstP628gtRaKh7QY60oE1YCc=,tag:cyTj1Z6ZuXUIRdpVc5xFtg==,type:int]
+            probability: ENC[AES256_GCM,data:h/AnXg==,iv:QygrvX3j1VLC9fqQOYEsa6TA6oAl59lSv56NM4P4j1Y=,tag:hfO8psFSd8PO9wQwqHB6SQ==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:l8xZANqtGtU=,iv:qmbDVo7fqTS1lVImcUi5NOT7EHTM5CHaNNF1dv0m48Q=,tag:K4vsOuiJrTiwAKxUCGwLRQ==,type:int]
+            probability: ENC[AES256_GCM,data:WQ==,iv:bxN0mz7FPRGAnrVdJIsUZBgIbYfLhuNIJwlfrkOxFDg=,tag:dXXkKSqYrWc6Plf7yDXrnw==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:O3uZwI3wOvN3ePhzIA==,iv:oO14E5fdnAspv44r4Tlc3eK9alRssVhnlzcE1ewSeD8=,tag:UbPKgH8QuywyW4KXMC+DXQ==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:GIlW1JYhoKyifoYOfWOczkKd+t/9DYsd,iv:N4RcH8vUFcYG1mUg6ljh1dHOX4nGSxtMphhupw3fA5U=,tag:ntCYO0tHQu4ridLISCqPbQ==,type:str]
+            - ENC[AES256_GCM,data:VcOU9kaEtVsi0cYwnag6pg==,iv:SwmLBq/1VXwq/EXoxTfvX7nHrrRejNgT/1A83DOpDBg=,tag:8H5jkFZAMa85+UE8dHqn6w==,type:str]
+      title: ENC[AES256_GCM,data:fJiMqLVXjBEpNU7KR43iOWJxJtGvlgJbsjrkbk/+ba9kWcZ4I3/OhaszL7Nj+53Fk/VJVrtWX/rMmw1Sv9vqkpTS4k+NUf/lg9s+wahGd5J7XYSq924=,iv:tveufCg4HtWiMTaqOGX2S9KZaeUqUmMYjxt/9My/+nc=,tag:oYCex1+8TDHmvh7MDECghA==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:0WwJYGo=,iv:3XvBxsGG0tEJZjdav3utI9vsaxwLcln9ALpPIKC7W/Q=,tag:M1QiiwFEedjC8PSNTcFmfw==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:X3C9SYw=,iv:A5E+gok0671XcaNGL4ALgfmsvic55BC4xRnF4l2/3Fs=,tag:QWhlYthrHi+4jkA2mZLJQw==,type:str]
+                description: ENC[AES256_GCM,data:bBIzhouId80TIU+1s3BPSo+i3htoARKjd1zlHmsBBnF4rULLuPowbnrU448K80VwKGiVUIMxacGexu5ryYSTP5yLYlnRa72I420WqnJWUU3tFVBAls9UgJvLN2UuILDagvljLo0zEKwHSneCC801w2dsdLXKPw8upp5oKa8xfa8GJkWWSaq814qYKD723tdBim3q0xeFPHAH/sjPv3Xm+XK+qRMCnd2bDhLlMlAz513rLsZMcaNg2QKiORn50DRE797B5Pgq9Em7pMk++J4Q0+TRHzRYlsfdP1d30vOFgBv4HeOwBuTtGP2wL+ff6FpOMHYuXXFlaP/yBhNspurhz6mh7JQteh4Mw6M/PkI3SjRJ6Qh0x1WoucbwLS1ip2EixkLO2nRgDNt/ihRBcgJf2/2gAGF6dV+CH208nzN4zu9tsrpqRQd7wjfGk49biTwxGZhQeY9P94XRAuEdPR2uo424cFlDB3aOxy+m99XPDBx73ZFju7J2U4CddK61aqmK,iv:km+uKof3rm/eXSyMRDgWNWn9RyE/WiI4SyMJhEL2BcM=,tag:mtXx4dthojGui8RaBEziAA==,type:str]
+                status: ENC[AES256_GCM,data:Ge7h7pGAjuWf4T8=,iv:SBw07nAw57nAGMXZHx8h0LFHWQj+QBD2PbP6Ioq7woc=,tag:N3M1xoQgm2XL1ris21qBDg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:vNul8x5AMDJcAfjXhHXQxWKNcZluLA==,iv:wiOoJ93o6GEndaJ705AfKIlXazyjNqJwUhKemF2JcNU=,tag:ft7Kgig1HSwXlOVv5fUfzw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:P3U1o9o=,iv:c3/4wOxxSyWGMpyXuoKgw1IJQE8FDlx27hkZIlrPJks=,tag:BVTkmch9FLXBdm91gwmFxw==,type:str]
+                description: ENC[AES256_GCM,data:73RitONidaj/gBdo5yB8OVciiEjVUMpvi7bthn9x0uIj/548lj4VPqrjjPzYbWPN71qGI8Fq8n+dx5BtfQ15Xc1WQukT5L/HWE/EL/P5esMMvRvxmSuupjO/vy+FwIqpyLRn3Q1eIlzGwBnMnvjnr+2cqoqzoj7WUNFFSzxWc4wFSviyBM3D/XiCySSst29KljJ5Oi3XhTpMKaWjLJep58hac3mxLbdVMRPrUPa24WHqaXxVYAbmG6PjSkcbfbpLNWutkoqCXrRVJszqSY1YpRsa/bOLmu1veld8ODsaeyU57ixO8aSFw9wrz8wAaEMFkg1fHeKqSZ5d4CG75ndsXPXK+Wk5qQoQfSErgkKygaMY12WWDbSEvCinW6AGjZHOUdQE8Rv/p1euKuAuieYTbBtdm5I80JueyejM0BTHOYuZ+ls/Cul35qXK8QvbOaLCD397kunDtSP0IwV3f44a5t4cFbG/CwiQi3Pb7OW52BGBpGaUdYv5swnUmkepd/yozpxdSm/dlxjkZ9mdN90+8EWkPOqC91wxEMCPKmoQAZWh6psCA7/TaItBeKMyOkhY+wTwQr7pWDserxL9RuF5PMCi3faYaEFcg/6px28QjNb13HuxTyZsee+OW2v1uHB4c4hBSly0duzKnYd+vorL6IYlyfY7so5Ithbv9eM9d8lRqN00W2bW19ItgRHHoRHchWrStm7trxWkiDbajKVJRd0/oyEQ506KGw2KEjdIBqjD9ui00Ha9b0wcWAGfPB7dUbMsuAZ5OGDgXdkfq2qP/FCiiyo40prnMn69OOSbZWFIVJhhLH0xawYCCe83Bfri8BMViq0AIx1S6NUkPqlMQHDDKJ/L5p/7UT1kgbOrWV5G7mPJK26Jd4d6JNmAwNTFeOA/l2ctqAvI0kJI7/wFq6gas+FI0KLuAP7lAu6lTPIC5sc=,iv:VgyRmgQZUaHw9VIuR1AAS9yXY7F0vDrdTzw0Tq7eWqQ=,tag:XGjwQ7sTOl0DZTmPQ28Xjg==,type:str]
+                status: ENC[AES256_GCM,data:RLXXHAU4fToHiAI=,iv:FDdw3wchpyc9q8estusbtA9nITCkp8IR6GpJvbJFfy4=,tag:Ul2/UaNyVIq5gRrnHFGB+w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:5p3AP1W439kUIk98aQk89duahLEGWFJ2sLth,iv:oix6QHbu0rvrv8u5vhPgnoYjrDJjFbcpucVWQyKM6wc=,tag:MxSwPNbaIaJdT264EKVFTg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:wLg7p0A=,iv:ERLst77K55RteV1nOPP99jepP8shnRGJCrp6Bq0G8Ug=,tag:8j7TT9K33alZjle0xGxXSg==,type:str]
+                description: ENC[AES256_GCM,data:BjXNMIXBg10udo4qmx5z4AXDYrSPsXYM1vcNgeT0vESBRghubltitrfDnVWWONno84/eTwBhjMzRP8vOFJtkZfRVvk9q6CZwzwC5ESjUWNReComIzlzhmPqQ4ka0JWvvee4u7Ms2fvUi9i6qIuBoLCr+3zn+wym+Rvv6L5QDUTMCUoZWeyeKdOxPp6QgnRJJC+tufXoTczyhuceb7ikPfWPaj8mI4A6tUtBk7ZR416zgxH7yR7+3JikDpMR4tO127UE/Ujkff+2dfMYdmnNhCLGpJmgZDgashgi1FnIqAM9rm3kjbNj+LkwO6MK1pS1updiBoAEITfHVih3HM3DPA1dh9EBoNY+rcgzI0foxJDddQk3mYhlkM8URdzlM3hPkdEM+EZRnMxzm4Yi/SuX7g7jy50WvRzacp8JaqkCrHuUMeTZs3Vlwy+bYuppmD2mRtLllYMPA269R0ntHHMh2LMwwZYd9zgYaChLFVjTjvthIX2rqwIKvWYQDuueOI3NYKUrRtSz9b7lK/A07mM702/i86iQ9347na/GOVD3g+5U2iO716YJy5w3dDxZsjl5ObRIHoBq+JVV6jAC22TYFBiOUJ6xDaHw6TkH2cZ9idXeSE4evvpgz3LDxJQ==,iv:b8Ei/qo0ntKDqFhBOpOgJtKlruBfa0PevKdJXzpOBpY=,tag:KiAfBML0+dVfi/ksVOIuJA==,type:str]
+                status: ENC[AES256_GCM,data:S9or/GSZGjOQg9o=,iv:l5G4E+IVpFUHe3cnrhVs/3lTsvDTq12R8uoVGkKGX6I=,tag:4KVV4o/+2kxdvxBkJSOXJg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:JPMKBJ0aTKsK3Wl+ZJH4jsthrqOw90zO1FWoaNM=,iv:nyVEyTwyefBrjmZDPb7NDK2dFF5zbfrO0LWGSOYiV84=,tag:kb/NqmnNR77ymGItvXOh4w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:R8wqPoc=,iv:B0xBY+qsCBKICrkmF6rZ91kq7zuPfdDJn2I+WV79Isg=,tag:iXCBwzm232aYT5iBNq6/xw==,type:str]
+                description: ENC[AES256_GCM,data:KaUPiuK70wbRFtOuK0TSdnb8OyBHyNh6pZeOx89htlTMfJwzt0ymK8Sx/w9Yxh05k1xryK+Ei24TRgSoWwu7gF92e0F1R+fPS8izPsXCUPtxmQ4wlCFYdxp06zZ9Zadxy375vKctmFn8B/PFX8ejn/YTX+16AbJrlR6BemrIblKc5G1pb7YAIETTRAHATcEeQkN5Z0t3Q1rfgh+rMOgVDB+xZKPf82hBge+5ZOdtjTNdWgglNCgbAMo+Ih+4zPPiJHtz9Dq8+r8p0djPySKYnSIhBQUUWaZBFjvzjoWM9baavVUAkEwPxmN6gGfEABaXPf4gwaV15iPlNDpEZiVLdncomyd7dpDdCyCyl4xrm0tebGOXCIUcLPo8As0HMI8VEkEudDIS1UDcoJfxsDjbipVhL2y5V3EWRZaFjakKfWLcDPZ7to0p1HsThg==,iv:j+2Pdq0AaetNVgTn06ijKNtSpGUMZ/B9Rs+0AbBIT0I=,tag:iNXBArDdzw3eBT4wRAgY2Q==,type:str]
+                status: ENC[AES256_GCM,data:SFLnbGRqILz6n6E=,iv:tTGzJGfxfs4b8E78Oqmz8t894emneY3NS4o82w//O3Q=,tag:ITzcNtpFAVhetg/pO18whA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:ueu6exzxfbqLYew4Unoia4YTPiMdUwkWMjA=,iv:+2GAMyx6rbsPsPS/0Rr7GY3SSQ4JjCL4fEAYMUP03k0=,tag:NxXjqurHIflq6Ti5v6tNaw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:fAxeHD0=,iv:LjQxRiRICpNEnD9R0ElS8zpVhicFloQWALyK1AUwpEA=,tag:RoRyP1ohZ4+uckaQ8eHQnQ==,type:str]
+                description: ENC[AES256_GCM,data:nhOwFJevAARoK9Ma+eTAQ+8pyUA8wyhTnhvFEfrAqqH3Ib4N3Lkn4C5m6s5mpW0OuAJYRK0FjLtL/fzqjBBUl9nfex2o9RHq62tr/2CIVnaR7L0LHFP41i/65LkvGfC4eMzvmgS3NW5nE97+sHD2qURFLQ04abS+SCTDVp3DTJWJ4doMV83bMtqqh62HLzVvIElDzCtP5fC9ATFaZ6a9COeZhma2GwtJn9sHjkSoy8e+xP0aVXq93hockHHbOWW6rxAoj0FWLmV+w4Zrlu4TnIsifevIqjPIC/AKMJBUjEJRts2xHIMLj6xFafTPvSR7CmjWxSWlzfv4cGg2JXk1iJnLm8bOOcDrm79rRk0j8Oc+,iv:Nz/MaHLKZvcQorkbsrVLcbR4qTTctEy1pVB5SoXoA94=,tag:iM8Pyxotl0oVQ5R6DK0ezQ==,type:str]
+                status: ENC[AES256_GCM,data:Ja/FEKU2Vb6aUXA=,iv:yJfq9CU8G+yE/nLSh+aWj4AKiy3+yP40dg+GwxeVXvE=,tag:R+YQNhxiXe4OyuHWJqh4aQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:Q1f5CZ1Y1/8vK1IRL+btlKpTXA1K,iv:33i4nJQzhQL4ITIrPpBtTNYev+a3Z6LBIz8w3wlO9gE=,tag:0PvcmxdOYmu4FMKwYMrRzQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:T/JzdUo=,iv:ycOWMyDoq5Wy9kryAP7W2bVMGUpPrvXga+6TEzkacuU=,tag:M1Nr6H4oe24EwpMKwf2q8A==,type:str]
+                description: ENC[AES256_GCM,data:o79i8Dk7vnFSe9QejYAgjODsuZ+OABh4WZ60nI/yDKZqWD7/fkwUQh32xrT2hiIDJKtf4p1PUIqhqO7OdmaacLDex36/0BCd9gB+sGQyZnsyCmeTLm4NJAwYyUciBzjGa0KIBUxdzg7pEaBKXj2DRga5Jj5mvdMFGEOedBypswtmPBM3M8PrHI14XSB+IrWlzZLzcf9RSs4cl8dk6E1k6d5cebhDtk31Gslmww4zy6gFDQXTCfTuwdqBHmXKhq3V73DfHG2g1r3ISt0Y5GUZLNqyD1MsSXHf4bVl5+ZKOSev7kgHM3rgzz+x+aCPpHnsg9HFghJl2yaH4qlh3L63rMoEDca8IlV1V6qeE+oTi2Il4R95246QybRI/MX1BzYLtHw7aVM3V2txlwcxjUg8OpJQqE+NK1f0xo6+MBLvxQ15ZHekpJSQ8I2JWnBLOfBU2o8VqQKQsDCORWT6HwMi0J3TI3A=,iv:GS3jDuK7nBxH2QBDEiIz8reG+ITtvFQGr//6QTNIuFE=,tag:6MYYSXUg1FLSGdbvAH04qA==,type:str]
+                status: ENC[AES256_GCM,data:BFDJFh56fabSM4g=,iv:7KNXNzCfx8gNp0/Fq55KO0kBUORgpDIwsoGo3nZO6jY=,tag:trV3KUtiPfEtztRz3K+TJw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:KOxR5Az8iYDOw9Wa4Kl97FY=,iv:Dn7Q1osSR6QXnsEbf31fQG5HlyVR7btO8gjEIVDdMiQ=,tag:S+OnAB1jKPRQVUlYgqU0cw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:FqE8LYE=,iv:nWvgFhZu7VjPoPysN1tuA7eMw4Hzip/RDGufkiVqhc4=,tag:cc9Ozgb+O8BoUjidlOPHUw==,type:str]
+                description: ENC[AES256_GCM,data:+qIj82g2Fc8h+rs4hoRZgWDlbO3A/LNQZNMa0hqZySgFoWTBfES9/C3bgTQALaTa+CXgr11LoeqNyNHAPL3wYkSPFw3CnxJ1pvuh/XX2QUEu5aAEr/Ro4Hu9gZahoctvjDe4o3Dy4tGKhSRPIZ7xIP4pcwlq22Mff5MTF6GVKglNcpoBbkWkyqqeLkD8KMXfTt4gjIbUdDH+99gxM1S5gXCwXuhchjaG50UE31c0pqBgvV0A7fcp7ZbVQwKtXQwoXUe0NldiUm6gYqcuMZZskIcEYH0Hivfi9KzTwtp3ytZYEWL1FMi3pIYIlcW7gFf9MarKqQx9dL4R3vGvB50KzV+EILFgW9FOIJuiddZ09w==,iv:AqQktu6VMbxrNfopzAGBK3he6s3nNQaDJnK8oQi1ChA=,tag:SmdoyABxgOTI9LZq8GiTuA==,type:str]
+                status: ENC[AES256_GCM,data:T9l76W8R/ZSVJJ0=,iv:r706+CE0+2ODm9k/NzhQnlsccsc/OOCZlE3o5R7jYXQ=,tag:Ky5Hd+gI+m9P1fBGN60CtQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:Y3HRk/tSTabI8hKn3arlZVwQ9APPU8PInhfR6w==,iv:JvCsETHftGsWREMcz7HfFUETKWH5Un5jAgSCLcdVmjQ=,tag:ENnF30SNWAZMT/4hDjZf9Q==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:khMdkpc=,iv:s1aQWnaO9eDenv3VPFpeNvwFrSLUt8QSLUzvKgPT/CE=,tag:BHyVWjd2Xqr0gv9Gq6lB9A==,type:str]
+                description: ENC[AES256_GCM,data:w4WGNQUJKRbnqhCqDDQcJ8N1lTLvtrWUUocKpByr2ztTNp8RxNqnKuxVYj4l3D64xTS9LzXaUhJo+72HbQ15+Z5Mk0DAQ3e5MQ9NswLg6sRSz4tMfmy6qPtlfuCzOf/9f3BVr+TgsaW2iNqV11yIdGd3Zj+M+x4kv4oHfc2l1Hz0WeeXXZ1uXLz0Nq3gRzG0gMLVVs5MeoHNyp6zYtIbvgGQcWaNCFGGIUbNNedvF5nrJpg4nfpdgwexn/hVCKea7nfhuPPYzM9RMcsHq0XRGEHkNQ44A5C/H/ueWHOLsHc/8guNBOg3Uym4ToSbdgX7KqUnO3ZBpBMI63eZZA+pVdQG38xpBX3NRx55CS1XPD/lqdAqbwyqfwOVGy28bCHk7mZsLkcXnn2I,iv:v0dtdv6Moky6MSrZWyoZxq+RHYQgDFnIUmcEAzee0wA=,tag:n1L/j9tYznaTpdj+Bid3mw==,type:str]
+                status: ENC[AES256_GCM,data:SLJHrv6y53NhT4E=,iv:uWlkwrWC4qr6yxJU1xY7LIMAh3ihYQgcIOkrIdZiA5U=,tag:K3FfEZKAZC5lCqYG8oG6Sg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:FAxrXGfT3aQmxo3Cd/0U4kxc,iv:e2EhPHaWvkw7AlCUf98bv6p/yXR6bmorBOwzS36GxHQ=,tag:BJC25VJqHVstVpQX3IhQkw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:kaIUwoU=,iv:0j9Ca8aOqvcT3vzj+HSJKilV4KEkfsfxqR8/OzLKcKE=,tag:tqqvN1p4lCiZxgwWsuKTGQ==,type:str]
+                description: ENC[AES256_GCM,data:OEp0t5boxBbtUcJNpzPOGhz0rf8F7vsh1ulGtanLwR+Du91Mbp/VkHQFfcdDPJWzyqvRGqsjF7tI4Xz5Bz3TWs3xu//cy6uhXb9PFW43R42M2TFtmuX1ym3pjbd8QKYOtih58fcMwoVk6JDYGThEnll1NzrCMwbwmGmDxmn1KoB0uvozV+woBqGDXbhLapHbRQBSUJiN7ecTp2S1xb2skkhmQROy21RbkKzy6tbcm98ML8d14xNRCEUppSq5Veo2Bn8TZQUzIBZ8mhPhP7yDFMPUJZr9L8E+mbOc0PrBFrI0OOf0HlTeCSsY957nVhAmg/0r9x32SH+dWipyy3AIR41RGLJ1Bxc1d7EOJGbMEnlPah9L56v/3jqtUhZzowxjO5dqfjUt42j5876B+kEE697JD161x9urdJ0jGq00BnKbi1GKBD8QNoiAd8I3iVt1oH+XfA==,iv:HkdmNN3GnEnEaHhH2HFPbA96skBsXpC7EnCKL/PqZiU=,tag:uc+L382IagmLfNzeDZpW2g==,type:str]
+                status: ENC[AES256_GCM,data:mqqSWkpzxOgDN7c=,iv:Uc6xxRTG8BYUfxjD2fMZy7qhytim0Ajm3EKNMBhNFes=,tag:+DoGgs2/q8FzaObqKqANUw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:oci9QdlU4Dk3E8o19PjlJX3ZNsA=,iv:i7cwmAnN49UD0F+6cbAWhTR/TSqGPNuX3P9ggCS0Leo=,tag:3TXvBV9++D7M7eTQ0XtFIA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:oTlHN2k=,iv:ct2AIno3nGw05KPhi+22+p6wcBmtndeCMOqkJ2UZld0=,tag:imrh1vt5CxgaTFKw8k5AoA==,type:str]
+                description: ENC[AES256_GCM,data:4GbCM190ErHB2omaNNFBLGBXyCdLjQuuOKjHrh19X7Y+ZtMH1maeh5Xp+WxZZkA1e0U2/0R/FKrpu5P12yzaWt+7nPuR3CEVksIulbIuhcyFnkk07s7Fbi/2Yvo1OuU0ksPe720ywtK6XKmS9BNxCLkB9ZHJ9XEh0zk3gupswr5Xo6d2ge0tU9XEEYo54sGbQt5DEbhhwDC5Uy5ebv2ZyXD1IHR1Yt71n4j2nxwPKq0Raw6L9DmTIwRxGSGbLyvdoBRv1caFOw7yfHFTaGBRpIZEkJoL42JTT23L+J1xHPe6AMLBeh3L3JdeBpkuCEDsNan/JnF0rJtLvq+PFk6oUdD/8w7pII8DjZh32EmQYTwcQrYqjonx/3aSY6mlc6cxVmfe18a9XfHTEJ4pZc4ZBRH/BjMLdi5EQJOEvB3qY+HG5Tfss5lsrdo2nNxaqwzUnpBUAsiz0503rU5wvncmpB3k6BKyOoH+AGD/sBdSJWDEtE9PYlsTzUK8XexFoAerdcQpmYceeqQJlEIWdN3ySdp1RICN2Nko1Ym/yo2EP/KFNcn6j8U6/Sr5IBQ=,iv:1i59lKSbkLJtY/t6PNC+f9D5PtCkTqRu4HJ8EfQ0hck=,tag:YWMiBb1cXr0aAcMZD4QFhg==,type:str]
+                status: ENC[AES256_GCM,data:WYL+KZMnxwNJBZc=,iv:vKSiLcd1IWYFW1KqLmETqG/LngtHs8i6NOvpm90GkhU=,tag:+jI55rwH1X9ImCMlyqgV5w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:jEWzEdNPvIYvX+5t7VBW1V4G,iv:itqFxz9RbqQG7EOwXiXPy0Wz6s5YakIWgCeYsWZPvMM=,tag:JiAeDb26tyKx39WWkNsSFw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:zAfouAo=,iv:DmVQ7ka7AO1BMl2uS+v5pXJVtTQwDH3w/gP8h6gzVkY=,tag:XtTnG/GoaI+ZupD/fCKGIQ==,type:str]
+                description: ENC[AES256_GCM,data:LFrLbGkgmXCsSRn/gC1a+45HgDia8aRF10ha4w6NwsZqn5BXtrNYrxZfGKO1HcYFWw88GfYn/Op4b55fXkanRPFcfFD9BQNb8VfxetSpNYrLADmDfMHua77Dth8VWFlQQ9NOSjqrNFdHaQVbzZavxbjAQsTpNu9t1+NkO6dCafoMewk7qA7wmVdX2RuXYdQQoC6Lz9lBqs51Xl7KxelwW2jpumFyKDS4ehr6CZKWNhRbcd9ECBAozO+L8ydsDxm0GvSZUF0jCfZHCicmaYRTQl1G1TYLR40wRat271fgXyBRfM7HWGl3OJLJC6i3H9xLJyqlbNXq0s3EgMuheLg2IDaRjG6TEWDKtPXN2Lp06lYFApO41ZUGl6XA2+ae+jVSY4eg6lXnPYdt482RH1fSm1f/6p+4bl5P5J9rukTQsS9kHRbH03xh5t7EeKNc4hBALX1oLPOp4h+IbFxMCudS,iv:VWdPIGsuNEwZNbOnHcBnBGcyADbByV26EhPRFQd2yok=,tag:SDV003SR+CO998IEhBxmMQ==,type:str]
+                status: ENC[AES256_GCM,data:6VVOEtS291XbfSA=,iv:xWEFer1tPk3eWwwCMzOzFOl1csfk4tY6CRURss/luws=,tag:jQoPep4ntCmXsKbYh9zyag==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:U8Lwx8oqEazNBYo5sATlY3/bxX88,iv:azMH/6KiVyhKSHuwhzF8QPu3/Kd6nGzRywml/ipnaBQ=,tag:GP0T/lItDpU05EE6+O0wDg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Pl0yvXI=,iv:yhLw0QC4LtT+YRN5oAAIELhEPP4LeQXOI69+SM+NzMY=,tag:hAP9vayxokXzrVhSvQrGuA==,type:str]
+                description: ENC[AES256_GCM,data:/yn/Nw/Pwx7aRDni2uOreKZq8hoNJQPNgWyYpsdv/UEE9pATlBeWDwk85OjRjSCaLNdKH5lBnJHkGF3E6YixxVCUhIJC6f5Ng6hXjDMn729kh0crtQ/EZeY/VyvbNWdXpPH2o5MuRzB4yhkn+/+YiLBVfoUWYljefVA4UcyfEMrOZFPdKhabQeqRsDzKE26XPZoVliDBSbonpQSMd71jZX4DsdXvVshSDFvzpDpmGyvDO1YTDf9Kk5KNNc/TUlDoK7eXftL69N7ckhsQJLlniJJote9S0jwfj69hbi7kkPYdNlTiEQ5AVDi9n/CAnTDHOBxDoorGpCUFdNYX5FJLmmzaBrOXEFVl+jyfRkbcLRN1s2uvEdG5dE880zlc8PQbLnDvt3AkDjSIqU0jaXztITw3ex3bhZptJT/4N71oYBQE9y8dtjGvHu2Tsp45wG+VyQ5SVS5sQa+7gXtSgzkaxzdGot6Kld6cMerN2xq/SOnEh+MVNwwbqUPoSqlH6oBMs4kuv220vO8MuWWh2Aun6iNKQLiit4AHFDm+fE+G1gOKpkhHTl5hBjCAJ9VaJAZacTNDlgVjqNbuHqBj7lsuJm/sOVnh9w==,iv:D+xt8IdEaSZGBB6pQZ4dyd8fBmoBHSuFhh50Drk6LBE=,tag:2Hlv2TFAMGt8vo3jikn+5A==,type:str]
+                status: ENC[AES256_GCM,data:xhXj2/hFRcxkdo0=,iv:bB+gDS9xKeD8p9+oWcimpb2gnmVLtX1rOImh+Yv+ZEA=,tag:dSsrw+dlbabQgIjaif8loA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:DUmUPfu3LDQHyIIm/IfZeg==,iv:c9xR/4bJ1Zbmsh7kalTkfQsGR0TFXgMAIu9T/yD/dIQ=,tag:ynjcfa8MlQTVNQYFb2v9nw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:FzOXpxE=,iv:G5yZOAAdiFSakyrv6uWBb9nXSeVPhzGyJ7rP1eB/PzY=,tag:LHLm6C5XrdXftlcJzgKKOQ==,type:str]
+                description: ENC[AES256_GCM,data:fQhxdsYe8eVvNVWTdWIPfwXp+lFGqI2PuZK0/sbagtoL/LBt0EXZ8zTMxZN+YXWkrJMGYBMsdP3j4lREi7LtLP+XiYXM3DZtrWSZQWopwYTuSFJz5DM5UGEIHPheFzDLIRcqTwoOaKmYdaLWzdlHRQ+tKKvjENWxRYGOiqO/X5wUo67y82FshNUSem/LdAbuLckq5yTDqo+/zQGbYXzN/ziggRZxL/7PdoguoDmJntAPkXn72idT2QS+EuWOq4lFnian9b3H1bCRzhogTz8bw7ZTg5KBA/nGVktYMbPb/7Nt7azNcaAURiQPRoBnJUvtyzHkErruZjIM7+tsQEpNtHKFhTjObIQepBziER7mzH5+c5jsDLYPSovB75ZrnM3ukQ==,iv:VSyw3jdP2nS2t2MMSub79v4kwByyDUUGydb4C3QQMPI=,tag:iIjfslCi7RDiR+oWJncVjg==,type:str]
+                status: ENC[AES256_GCM,data:gbBLoEho7klf73Q=,iv:b1FDOAlVTbwo4HJxyqzSnkLascH6n0brhHW7Y+L3VZo=,tag:fLVyGpaVFoaKP3nCa+ppsA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:nQxyHw75OlMpFfdzS0ZT2aHPgekrHm7ZnX0=,iv:g+xoovV53fLTWhWemxnOfy/KrubuJY4ALTpjq0NK3pQ=,tag:fhMzShG+gcNhpnR9hGL2+A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:n9rQJeE=,iv:xza+UGQwIW5oAdrKZWHgK4hsidHVU8rUK0FGQtWE/oY=,tag:C2Os+FdAi+uBsB7pxuAJoQ==,type:str]
+                description: ENC[AES256_GCM,data:RCXvk8UnTZsVnI2GZ7XHne/C3Y8SIR9pZRidrnH8Qyrkk6SAMvcGqAXGhi9WSSpic+H3k+oD6smUKrJytqCAIhWMNj4oP5+mIcf5H/nbRu47g+W1CCVfKuBluHCzQbKgR1KwSeiQb87zKlJUspfQMrL6KtZhF0TKK4FAM7XLd3BQu86f6wbps2E6rDFyodIp/hN4KXRUkPH0/q7BiyYGPvkr48Mvd0W/Xui8F8FbX1vjVj2Gibes2NHB25wp/j6AzeAifQSgKzc8GIH6XMzbeBFMqXfUhqx1U1Xt2kKu1sDILPs/ux6HQBylcKJqs6twIHi/HWkQSPGxtfeQgL7RNgXVoal9Z3bGhtllE3SFe2gDXnjGzCNO2IbOHdn2qVcWJ+faOBYpDi55o5bAHOQaADGJZ4JOI0i2rI+mM32LIEX2QP3Zr8qHx5++93iCUOQqOvhwpPvhm7hXYks8vyU2Jjvt5MJG9tBObUlUuRaKHUnB+8sJL9tyWi0=,iv:vo2mL41Pzzg222aVVrmVw0vWNux5GgckigBCDnccAcw=,tag:ZRu7WKg5mAx2C1ogvVqNKg==,type:str]
+                status: ENC[AES256_GCM,data:l/3GbT7eE8j1L8E=,iv:OAsirRQAPNtH9BoVp0P4hi2/2iA4ry/x3rDlvtndfLs=,tag:s0F830V7M0cFRnapGSSIWg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:hRk3j7ggLdPxSZ1iiGcB3tP01Jn+UbeqsJNU,iv:jH1HRP/VAUWggGrVwgG7Uiv5SMbyToJ5d9FIds852H0=,tag:ftlDHjFcqEbtBrb1oJ2BFw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:cXHMTHM=,iv:SPNESwEikCU40ZpdldNpo91wUaEcsm4Oe6UZIdQT64g=,tag:g5uFQUEL07dMGaVIkl8fJg==,type:str]
+                description: ENC[AES256_GCM,data:ocTWyOo2wfbDKULCi5OgcVj/e9PxT/e1QH0oMq26yKT7oPMcv1DN9n/xE1xtNH5odaOSDR23UzDPtmxf0uhPcX9LtKiwwhxZ07CjfiZePaTYyAbZvWiLHQhFfroVtScdOySkpeXDE5z44oz6i3+aw8vYbOXkr1JiCs4XvFU+sI7gbfH1xvTG6TpcxrwD1IKe6lAVJFV7d/IQQ0pMJeJdWabp5mZGym6qqYB5ghTFY23+dE5ocr9FSrdgp3l2QuBf3LE6JfvNbNNIH0axuzOb2JAGBbhfr9+Iq8vol1SCQfSUu3MEzV5pwr7/JjfJDH7H8sEYtV9wzOYxQiMD145wSAWth34PGQ==,iv:Nr+p+t9yUxb58zG1ay5deoJJ47zf5XfO4jobKne9cPA=,tag:2PZQVsdBUEcw28LshErZhw==,type:str]
+                status: ENC[AES256_GCM,data:YLCoEH6n1orFTIs=,iv:YULFb5+91EXW+k/f7smmmbvlMsLAPcqNsH/44FL2fA4=,tag:W1XdnXpnij0awCZ+BgPUJg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:sKO2uYjsr+CO/to9cTfnar8bE6Y=,iv:o2JaGy1V3cqgt/VWZoFAebj54eC6w2hPv//GZo6lHvQ=,tag:JzgS+HybP+vB2cAKRQbzqA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:UcgVuzU=,iv:li4NWWfWQBG2rao3prJRMT3l92R9wE4PfHPeXGLfCRk=,tag:uz0PLPFyZugHF1wAExVsPA==,type:str]
+                description: ENC[AES256_GCM,data:gyzuUeWvU/a27eqD8LhhPAH2YuMc3OpUieSeGaO9Udpb/pJM2E4KuXaaEDtRxpMj9tt3KbNg7aV8XknGV43+GjK/EJCl8eKgSwOaWhvtc3Oj5SI4Wohg0kNHEuZBhcDAKltSx8COxjnXP10ykDQwhf2rgEXWAr0J0RLg53jqLcr3G5TnTaHjU12m/1ahsb5OyWZwi+6T1SIU1GZ2e9a6MhJY0F0UNTxYXosvBUWZRa3P+jfZtTnyf2YGixXw1TEnXOZ8ZZ9j8AL8EyqONuEtoeYnAmAq4SpcyD23PrAOXaSZIfFh3vLBSPnVLl6tRsNH8SG/Bzdgv8wOx5zgjGh09hF/AMtv2+LGZqSKdv7FvCkgH9fBtgq1MHs1QWn1xwZbpIELl4cUFFLol7OiNcdAF+Yk3tEj0wtnG2HM89E3yzpoaYpz63w=,iv:uuYro9cdj+sP1pUsw+6JTpHb8OltbrHZZ+3P6ywWCfs=,tag:gEnYw9QW5s0jFBVVUoOGZQ==,type:str]
+                status: ENC[AES256_GCM,data:nzjUmf1d5fqgyEY=,iv:BGMluOQ7pr8jrkJJkBHDx1ohWw4RILJZHcODutiVUqI=,tag:uc8GhA+6DE/FlLlPecJqMw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:LmFuX9Tvs2e0AX9MnO4rNTZIacAa,iv:BlN5xLGrAxVCeeKyxjAoxnL5L8Ka5Ib9RE/UBH6ndKQ=,tag:hj1C073yaJfO6X9bKQwORA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:ZqFlYBU=,iv:m3VOExeZtg4OCionRKXbVKYcoO5ntuuXsBQfrTA9N88=,tag:pKFBx/3nuAp3mBm3wp4+zw==,type:str]
+                description: ENC[AES256_GCM,data:rwun6gWjidFaapovIO+vamGyBAA2/aQyFHhiCnMXKfR+OcitfSy8XeT2W1hG9TKQ9nhTIxI9hQweNGsMjeghd0iD027+H1sxUUoLi4yOVF4cEdxkgzJK4eSPY4fcvoQJfgit3/cUtL692QXfcDrhPyJgGHJDwviCY6+0IDE0cAz6QUz43xec3ZDue7nxEWfmjq3J7juUOHRW8VmQY54B8+DekAImuDK9G+/iXOcCPMsBxCUW2Px7UC53qhQKOsF8Nmy/ZSdletXkFtEH+JmJjYeN9v0H4t9+p0Zg2hQTQD0+3fTMKpPN+BjxQwdP921qZ1pgjUmTNgd7E+fhmhsGv1eKDeqsICZ/syvEuPdaCuATHGlxhlr+PMFkhIr+Zg7SVvEjOz/MKflxBNhPG1HYBHrBstnVuvnilUz6TzQAA1OzRP4hR4sgarpxsHHWVkgwK3hslO7ApTHb56yRS2QRj4fuBapNMw1FWWeoUFsyxzOtsGM9qY4YSIbulsz1SNGwAkFLGGOHxQnDZaTCBfOw0kioFkjFFG2JOyMoPm55DwByy0/5TOy4nmi9ifFoeYmEy8k1DSqkULWtgHwy,iv:7NRGl2K1TQlFCLQQ/UAul03Z4hCRFfX5ueRhcAYgv5M=,tag:pUep2uAEDsnfajJ72IT+gA==,type:str]
+                status: ENC[AES256_GCM,data:4zGdOT2yhBc8xKo=,iv:PhDUKd79mkz2ERUkgQCS0asMTc+Oc4anCgrc0o6ysbA=,tag:WivFQu8wsdyo5xaFJLhiYg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:X09bfcqBLZhm/kCsFq2uK72MbSZeYDQ=,iv:wNCPP+JKEh3GqNu5JCO1d0i6yugGYbzoaRk4iKWbHs4=,tag:Z/D09pTdmzSy4lrcKk4wrA==,type:str]
+        description: ENC[AES256_GCM,data:JJ9uN5kKtZ+ngSv2pK4pARWFrY+EV+hh6Uhvf+J42qjLxpJIMtOER+FcoYq8bxZmPAksfsICvRQKv6ldbKaznyhsIgQCobjn0XAAUFdGxBjgY3mvn52kkgyvD99uMjx56MzgDvv1m6XagX0L5vLD65v3MGe65BXuldZ9yjMjSte4UXcF2lcWIRXLd50iOkSqbtD+yCY+wi39REpMH92nobHHH4f9kL/dSQuJBHMS+j8A9cDb96fZN3aN9IPSbKOVbM3FU24nm7GovtCYa7G73+TpvlIqkC6oL8rYam5J5sQPUpqtcw2d+bs=,iv:jnPBv3zmrlLCkBMpR6mHlOI4TPMfCEz7sALWR+JnsbM=,tag:8iHuzgxrDo2livRgCcGn6g==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:79JgOQXNNg==,iv:dIUSeCKB4ic1JsbtAo2EBe1BgBEyc2loMoQ++fqkQ58=,tag:KWyXv7wkeCL+I3T+YBo1DQ==,type:int]
+            probability: ENC[AES256_GCM,data:l0biww==,iv:lOYGZOi1QPtTJsuFMhG7Pz6QxPmrmHqz7LCUOA0Bnl0=,tag:nmqMn6sbvBBUJWS+G50MCA==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:kdeFCOf7jg==,iv:P8eyGyt+8f5Ogt53RGHAMcp5lgj0XTzoiEzXQxzWFWw=,tag:cLpnsV63/MsDoz9GcyJoPQ==,type:int]
+            probability: ENC[AES256_GCM,data:cg==,iv:oPh9nP5GKJ3cnh0r35IYgyQnsXS0x8L86KwIUQsmwBU=,tag:UYkiZi/BIWyRJ4LiFg1I1g==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:hn6j1nFVEDCQvg==,iv:0Wgaln/YxeZnestlbik+RSllPuVrBRrDOOIFRThnekI=,tag:Dr+XDex7o+rKgsfophjjAw==,type:str]
+            - ENC[AES256_GCM,data:13wXrofHOMhgaSdsYB88S8o=,iv:ADCcGheAONKjjxN3LzOW5gX9G8h/ivtQjPMJkketnYo=,tag:Mn8VFqJXmoLHvdVC2W/TuQ==,type:str]
+            - ENC[AES256_GCM,data:yiAQAzFh+g==,iv:c8dEP/n8INFnmjEQUZaFX1C/ZWVKJxhrezBT/xiICek=,tag:AQITx0Cms23wtLbn0GL5ow==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:Bf9b/l10UoWtx+OluaSw,iv:fSp4CgMeh2hRTr+WnM6LQKkYJYhhpTUKlOZ3ZhuEoEI=,tag:XpFMUMLLKKGJXC9iK0dupA==,type:str]
+      title: ENC[AES256_GCM,data:aeIPf+WdsqYmX+E+n/ijqasr+tUVTdZr0uzFsapTpnKBF7JxtoYvxgzImCuwuRj1iJcxz1QyDNxG82R0qK0iJLi4fjhaTqQGgYGCTM2PnVF/Piqkk7X490XdPptIbhU=,iv:ncr1YhllVygU4ahhVJ/5dO5Wg980BRfNftEeDPh/sD0=,tag:vhLO/a1JvK1oAgCCj4o7KA==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:wTjPRAo=,iv:wQTnxlPBoUNgANBfzKJOw5o/Jzx6p4GhzEbCceETfxU=,tag:fu/UgWDkB/9Ba1tn5IPDZA==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:WFCqlRM=,iv:PkgB+3OFinczso/f++S6q35zkRRugAlt23dfp7S76dQ=,tag:wMoiE/1T/GzJg5peTWFhXg==,type:str]
+                description: ENC[AES256_GCM,data:C80UHbAPyZ0FVmyMXhGXFFhqyuxg9rmj4PavuDMqgSG8K/0CUxN/3OowhMSDpf/JtXdRgRXUk+b4OkTrrP9fH75KdSsEIXgnyD2QrYTEiPMYFN4lS4FaiN9fJ79oTdaaAP/6QCiOVJwvzcYcGkjq35VYjJtcGP/Bci/3AqgQYauYm6CjY+/8B74+Gv70mvWIQBpNMs26LMa4W9eHd1hvvnjK851razww6+iXzzR4cP4ljnZPH80O3RZtiRcgiP1DdmW70jtIE3z2iBXEMDN6mh5rqdDOabBXgGGR5zurMXPpkY4eEkyLn8TRpWR+FTQ3Y+NH2AaCdzitdb3uyj8jrJJ1+ZwkmZpCC6x7zLv/HxzVEn20wNeMHfh6aq5OuhJcW5gLd71DUg==,iv:pdqEkpueoxZEu2vmmhGrsA/bc4JDgqtPDUqzl2zNSp4=,tag:DqdCrRt6XUsJfnxXLPJhRQ==,type:str]
+                status: ENC[AES256_GCM,data:5gw/7eeUhTOsrFw=,iv:2G7hVQIy3oVWdDZfL16TnGGGPdIEtXRAsuJivlb+9dg=,tag:2kw14q4JWt1F3No4Gxukqg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:c8PcHVUx/Aa+vEZlePgmifyJ5wH+9NX0xL4=,iv:0UHxM/VpOdCstIGN2eb7o39RE/lYZIfSef1rQW/LubE=,tag:H1Evm4gukz/TmJyPpeJ4UQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:nF1s15s=,iv:1K/EeLHxIZiWpVn494nFlj2/aiRj3pyX/Q01ZyWBQFU=,tag:lKVV0b0cTaomEsgitjUvQQ==,type:str]
+                description: ENC[AES256_GCM,data:NSocrtAel+3j2H95yPTAurGIwhOkUx1KakzdnTVcdNZ5KDWKC0/8SFOOOH4FtHVjAKtCwlo9ixtabbJiw8mooPQxltOFijxoyM6gSGBN1qx/izRP/M7PzlDGf8JzvBMCUvx3AnLwPNS6dYtcbQfYsUyLGNvwTuT24PPBNwYmfwddta2CCQjNBFuVkiYbMkGUSYyirffmyVv2qyqH5soe7WpUsY8ZrrA76kQzLD7fa0gWi4Xn4aGGkxjIxAJG6EqW+MulKEBuru+UwQ6ZBzbpqURcw8qafAW/xQ2HQzCZOkqPcaWKoBYlodNJt5oRUis3eQnperATEY1fBJJOJ5L+v0am,iv:8ZALN3SLAhBonpjXFHWyNwTVBskcO7FqXIyq5Y8LcYI=,tag:ih93lnTX+WfGIRgItHFMpw==,type:str]
+                status: ENC[AES256_GCM,data:VxY+wPgkltEwWJE=,iv:fR/4BamVe8VEXS6vsS0vubYC2NVPxyl7veT7FQHXpQY=,tag:h/yHnZ57GaKsyViuha51QQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:LxjKShSO13gzCf6PebxrX6A8Lzgk1xvd7Egu43FS,iv:voTVk0MqySwXLXPxkLnGphpsG5am1Zd7+YdoSaAgDRY=,tag:AxQZ9Np6rHsRe60dHNS2pg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:f3qVBYQ=,iv:B095MtOWgqOQPtKdIFznAv8Tl3mlyUTa0rPpxWxSq+c=,tag:mhgg1rrxAyIO+1We/pkGsQ==,type:str]
+                description: ENC[AES256_GCM,data:x1rxy5XeRCXuCuwvSecgjFb45xMYEmiTRD4clUdfqv7Y43L7WZHM4uX0YX5HhtSBR1SpYEUH9In9e1uDGiX/Tqj2P1hiSbly9TuD61KAc+WrviCYSVB+aaUCcBvP1pYhgK2vfntKEU/XzlgGAO10b3oRgeh7uyMchYP60qer/RgJeYPEAI6t8pEYIzVCYDb4ukFADhKWfl3qzeattWhwHCmuDIA0Adl4FtPzM8g9W/uICYXS/zDOMQU/FVNtfFUXaAKdc8qjzHiI8tuV,iv:b/EZ2fqcYDihLlvE3xoDCWgyChberEoLS6w6KWD6Z1E=,tag:RkO7tuEVOPDLhU/ygkNKWw==,type:str]
+                status: ENC[AES256_GCM,data:QL0q2KVlP5Kydlc=,iv:6iMtA+cZbFPYPH7kRYdNUrOEpNeBuDnc/7+eBdhRrm8=,tag:eJr8jagkfKa7BF4pfxSiWg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:p5bFfeJPiFgzk/1dK55E5BVnXOmj5oB7IN+V4gIcmag=,iv:3t2f4xwuk1xZ5KYcc5gkStQMWViQ0Dju8eN9DRYwoeA=,tag:lzCNb2L+zlkH2iWzrWescQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:9dfFjlo=,iv:E5dSKrHAyRSUXE/SUiFyw3WUyA4+wWvlN80NVQRzMI4=,tag:30cDd/6rWT+81lTzr39Sdg==,type:str]
+                description: ENC[AES256_GCM,data:C6i2aTyuGUUTclX02vzNcVXw8aljVYNTN26sBRoYTPZ8S28P4heD633MLUXqRgNSv9FugStlLipTT6h6CV9QCH2zscy94OgNbzjV5Fp0vuxBnlwIL3BN5xPKM/EkThcHBZvkbESQCEIhk0ulwXi4HtsXUgUx3a36oA6e9HY76sH6Q8QQKu1c39M1VBFru/Sk0Nr+s+ElNSkvuiCAajNKHftYJ1ZlHct9Xq/mqhACwgLyoATupUfGPjrorfz5k/RxPBJs9YWQ5R8k,iv:s8HM0OILXfM1zxIgGhdt8IErAmy4U20h90bPfly16Tc=,tag:TfpmqxotrXMyRb2Qi8tVSA==,type:str]
+                status: ENC[AES256_GCM,data:cHgGY+RciQH4ytY=,iv:OXFEVk3v96susyb1jhH/rdDGm5vnWX0NUGwsFIQepS0=,tag:R4u6ibFwLZwx0xf7gUXEng==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:Ic5W68RxA622ldY5fJKn3/1tupRj2Q==,iv:12yzu48YZiaJqVhB0YxqUB7EKnm8oC5NaMyB20nMwWA=,tag:SKi/P3/LtMAq6W6FVtc4tQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:tHVjgDk=,iv:IT/ymA3ahTkKnv7Xj5Rec51rZI0xSKDQPfKQ15MoFc4=,tag:jxFAt7op4cRslnIjPNkEcQ==,type:str]
+                description: ENC[AES256_GCM,data:wy2Tt0Y8qEajNDr651yHSGga+GNBa9930czleaLTkyzf9VPagSlhZO6o41BsURnvobGF/tZkn2oXscM+TQxN93NLKch1W2+nztX7rAkUvLvEp09SlWFp3WeB91I7vkRVjveFg4gq6J46CHZaD8I1pHNcvSZuB2fq4bioMBYnMkulJL+ev2micflFjRHEHKzLRdTILkU3BS5sJq2Kufi0S1lO80hXWqLPsx/yObxyUed+8EvJSS9LGYFPq9P6rhbQkhQ5shu0SYbv0F/E+g==,iv:+GlAhpqmJpjKKSdcNbJRC+Lr0tQRtne0qJLYNZrqrFs=,tag:7tdhWzkGSr8lDS/PcTCfWA==,type:str]
+                status: ENC[AES256_GCM,data:8GkWqC99052WlmQ=,iv:9NntQ+N2Rz+YwFiU/Axmv9PMaMNL4tVzK1mcTq6emF0=,tag:iMXRiI6pUMPNIAcFXtoRdw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:PGWUQ5bDiLsrQhZ8Gnlbz2jlUWM5iXLDjMywNhrn,iv:98KUujsV8kz++3cspV+mxp7lzvhIIml2IQHnodtz6/o=,tag:91NRoNVPwFGfzioSPJS93w==,type:str]
+        description: ENC[AES256_GCM,data:8vb3s14KEkD6QuPsh+Qe5s3D1htFbzccaRMA6GcK0Yw2TwpjGQQWEfJPaITucP27RlP9SPhiyaaeRTv7wRXN5GGHogi4/O3yoNt2gWo4IEHIMQzXtGG53lnU83ijkweIJOzYqVr9rzdHQMA2Oa/Dob9fT3jRz1g4/XYgO9uGzBM60RVOJefXPz0S/m2vyFLsq3n+cqYlAfp5KBokdPX9hpmQViJN8fv7HlrruQtI1DHNsmH31AhyyGCyemTJMCbVcV2pOTFKz47CuO4GQThwVRHvU7vdIQubeytBq81+25Htnki0LtLXvYW7YK3P9f2B0z+2nk7zjYdeTXjt,iv:4hd+g6YEjzG9NFwjfrEKSBB6IwtKzErtnfq488og0KQ=,tag:YY4WJzFWjX5boIMIAWVztg==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:xAlPx6aEww==,iv:VgzibCQvQMUVklJgo5YnrkiJgeC5PHILK8LX575p2aU=,tag:iwFP6BVYMNonhT/zfsUfxg==,type:int]
+            probability: ENC[AES256_GCM,data:OUblaA==,iv:1zG0xw2WS/EajGRQoCj0+vFC4+y32UFCHy2rdOz95sY=,tag:AWC0jtWXW/iQp3Aut+omBg==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:dlx1vApo3wc=,iv:J1A410qWE7yyqWr7YL96Rc3zWUWwz/LJq9GNmpYAF6g=,tag:nyTTqgvJi6ZX+IcDlSdWAQ==,type:int]
+            probability: ENC[AES256_GCM,data:8EZC,iv:dC3NGy46lw0V89M3E+Y2DcmFhwKjQE6+LJIv2mUr/ZY=,tag:m2AJVo1oUDkGfNAFI8INGA==,type:float]
+        threatActors:
+            - ENC[AES256_GCM,data:CCf6cYTuEtk50orwI+WD1Xk=,iv:k/XxdXUHDL35Qvu3cN+CYsiUyaR+uxDEKdW6Qg+Tusk=,tag:Y0uXHEFC3ESheVVbgWhCHg==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:IYIzu3aqdDUBki933fsXRk8jpCoX2xOK,iv:MU0TKtMbrVFnuUGCXJEM6hX2F/NKDZvTW1WGxnx0SSU=,tag:deIjxqgpKvaa7j8IcHz/gw==,type:str]
+            - ENC[AES256_GCM,data:IC4akwCeg9B0UFW/BwSJYg==,iv:uj269hk+aKgksTGJt1iNlmGSTwWbpnvxLB57ctVgM+Y=,tag:MqujjLJ9kcxgnwG/Z+bV9w==,type:str]
+      title: ENC[AES256_GCM,data:Ak8Wmnjk26yfIuUqApRJjq+qS1hdEaFZPLEgos0uuL2DmgTce7e9NNckfLTYdR1uiXhj5bxmpfZsdGpIMhyhnlgIR7KR/OGsFzQ1SKl26/24LQ==,iv:cv6Wz7XWHtpRxEPN2iJApgGuiPAHQE8ckca38IE9CFg=,tag:h9SWTTO4TORMsG9uvX5Ueg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:NfdE6YU=,iv:B/KfnBHDPvfDqWwjoUrYHoJxGwIVn6ESPG8b1CSTm0Y=,tag:OoUfH3TjguRcCkt6aVuHpg==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:IVKn8Uc=,iv:+oGpmiKXWhB180dSQ6TaBv6Sm1FGt0GiCsbl+21OPvo=,tag:/8doORaD/cO5TSs9RBJYVQ==,type:str]
+                description: ENC[AES256_GCM,data:zh9S7pXA739KFv8Bcx9o8XLLp8bAoXmH0Fs2Bwr1QI9+zlPruA7CVvqHfYWl2/TmNu+D/O+eW2dpgCRKhaL1sXqPueChCpk10e+1n6Xe52OqhfncTIzlzawVo2R7Gfcbt9re28HwGYJXv/gqlp431ARpBKVfr/8RP2Vl7qZQ5z0iiSL+y/61QvQfjIFqs1B8HaO1xj6VCfWfALRYJzshNjtM4prkp734ZN4crEQqfQITBA6fnV5iN6jE7zxw2i+o6Q/A3qjhlV1oxhyncHMFUS8T/qHKMFQtc4vlNg4j6XC/VaKgLvDutlB6GDWfr5+JuoeBnMuFskXlFH+DwgbjcR5i3iICPXSn3ZxRxC71wQQQx0hLrA9hziyi6a7rdztwaw==,iv:GP4GcFVOoxHilrKGvmnwRdEBOnyW8Mkn58/kH+74buI=,tag:9Jf5UC1ZYn/svDaH+7WecQ==,type:str]
+                status: ENC[AES256_GCM,data:extfsTE9wiglwTU=,iv:qEEyzvh5uNN5LEkyNBUaIZkNkis1Yg/avML4Q9vLkMw=,tag:AjH3XILqnUdS5k8N6K55xg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:CoIPfeql85jxHU46AJmp51IZfn6wMlBs,iv:wPxnsIDSLDDhnOnmRTWLnR6rP8Ck4iu1dLxe0Yc5b2c=,tag:2tvm2IeeY9I0f+WaFLBDzw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:SWZmbXA=,iv:DBsQnj6KAsWLYt6LlzqVdPHoB/CaBCXs21c+3EedTHE=,tag:hGpYcKOL4tR5dewd03KV9A==,type:str]
+                description: ENC[AES256_GCM,data:SKSw+lW2t0GwGrLWTsjZTs69k3dyzyu9KKWDn/LBAYKYNudQC6R+bndr4/2ltcFQsPFoK2SqWebsXquPubZ8gxiFTxeTqvPIsVkmtiIRkG3p9HuzgOGEpfIuCts8dZLEzZVjS5qS5cjEIlWO7AdEqn9PAAWyI8L5UkwJeOCC8Jj9LLahjWWXdiUWYp9PxMB5DL4Yuz+WqT/V+I7WCJ9YQNxnnCoclndUVEL5nzrooGoah37DecrIjuBTjN4z/pN34s3hQErw43bPnugZK8X+0cFxv8hdXapSdf55+EO/5WsjJUKr/RLIawvskNVfPwj3pfBCXMlxhBGuIgmeNDEAgryV20KuOkKpW+cf2ejOnxoAco0IamMnBJaak90QmbjgQjO7Z8YbkSNR,iv:92s2NCJ4reATG/EsQHKwAFADfYKXC2hAfmKJ+W5Wbr0=,tag:CWZvfkhj1MArUZ1RtjqZXA==,type:str]
+                status: ENC[AES256_GCM,data:IeJpP0JGrcGA3Kg=,iv:ml/LwfTuOl1lgg4j71LQ2Hip5SLu5C71Lq6YkoXkX1s=,tag:xuvBEdsT/ccBeYyAd+PW6A==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:mOhm68gHYfwxR+8rnfATLsXm,iv:8USWNnDQo53GERRT3Yx+BTFQsEeCtPahd5T8/l838x4=,tag:OJ0QVEAFGukiE84o6QqJ6A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:VjkTerU=,iv:D3Y11Dq5ow5wRulgsGAdYdp/Mju57J2fmGanZrZX1bA=,tag:TOx2G2pLdTDUirj64juSNA==,type:str]
+                description: ENC[AES256_GCM,data:lOLZqbD9sm/nuwbjxDhvokV96qJ6JEGW/1lLZSx6M/zqhtscW4JAEvOOFDCJTCmV4Wt9lGqhKBXruYQ75B5gdFzixHgJrjuEVhzDI3AjGCoRFQ0Ox94f1Ri0MDc6CdHpFas6WPdq59dv/Ab9V34+gTWokjRGAQQGHZ/+1KUGPqG2UefO2XZONV+o5/qXn8WPkXWcVja7YZ43R/ucyXedwZGQWYenRsdoppag1/nEAKKAtXIorgbbWIWMQjnFFanTp4RqZkjnQMs6xFLaldfUFxGmFg==,iv:UPRSAlLJR+EhLXpT64BLaQHrgC6k1U+W+OzuWDyzXbU=,tag:dkAZqpAQ5c5IMW9+RQFL9w==,type:str]
+                status: ENC[AES256_GCM,data:EK2zAJD0Mn4bi1s=,iv:rmVEV9unHal2ZIrVvAfahrAjYfF7aA7hCSNpTBsgLdM=,tag:0UXlV+nUzYTtvvpWLBFPpA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:O3iDKlZs7z32vqTCQYDxRVEUwXN8pw==,iv:0tbaqqrQQiRJlfcThms4+SNKbE89KC5WMENxfffm6zY=,tag:mcz+lpch7jzCwuPC4WkGGQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Mty4HQU=,iv:/bnp0H0/2JkLd+AuDyxwnWUET3nFzcP6nP6ZHeOVk2c=,tag:BQA0UG91vol/xiNqb7PGJw==,type:str]
+                description: ENC[AES256_GCM,data:2sxMOGVTVhs48UPhIfo3ge3jd8V1wWZWeT/C/D5fSFYBVhMQ/U34ZStsby2TfPdBFKxGB3iUiTOIiiNGD9KRzjAfNYO+nUn/xsLJFV+z5B53ndexUT9ZKBIbW2ORoTu21mldgN4psEbbGI6jNKS6SWKSo+jYPiABcTx9zi3CObB79slwXJKcGBpx6jbb+DzcgCCgt5PFawKrDXCMvZtfqsmDRg/NKCIDblWFlDLRnqU3aT0Qb+7/QSRbjP3gg+IYJSS9wOPrqsTci/yHpsq5zGQvI6CiRgWhPBNGfOB3sRc+m5gtLW36ImHJPcRmgXOFpMcPXAgUDmOdeic/JGJ4+FZAFQhb31hhASSUEViHaDjF0TwCHImc4g2I4GfXG2hyjLvxXnVJsFK/ElA1XgxP02EUAWc44MWuMc5N+RLuPiqqtQHZgQkbMBpR6yWDOF/m7oh9vZpQvBckZdlIcxfYSiHnLrEpNMWs5+nVmxfqrYiTQd2elullOE2wcBbwNYNEJoDdiNdRjMgZ90Lox3SDaQYm0RwmQ5WyipJVU0Oof95DrZHdo0OZsFF/SRnu4vwNHGR+HW6dtb5n8/ePLHJwBHX0xbN5LGMI0dgvq3udLEfTueDA75FjQFB/Xev0t5ShDv5M7SHAnXQu9b+ZtcVqPZmw6nIbY7aWxWwAXkaX5qD7,iv:jW8leL0Z0UbRXypq69jsy2jdzMM7VmpDPi+X0/S2t4k=,tag:Qltwmq+olINpkrmvMXW53w==,type:str]
+                status: ENC[AES256_GCM,data:c13Of/Mgm27O37o=,iv:bcgJ3IofKml/cr3IbBpzdxW3uP/afHX8YSUZCHakm/I=,tag:Im21jzlc2ObIYLBEg9ts2g==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:5ARilKsJRSUMKMhgH4hRnmo9FyI5IMoTu5w=,iv:P3hjcdIJ2a8NoKHwg4lWegWySN9pQM/y5ndmXzUB5uA=,tag:W1JWNev+sLWC63+CbTCBbA==,type:str]
+        description: ENC[AES256_GCM,data:XvZFSYWpi8qaHbWzGvYQwH7uAbcz/VIAeP9NY5D5O84FpUFifDoczkDI0hVRtwdQ6t5N2dUuQ2MJlbOZvKBudfbygksDJRANpgCM0BmKeiXKYTTjEr+M/4PcC5XWUfwjMo9IoIh97QtEChh9DZue2qAc/6nt97FUEEcTaCIQcD/iEC5AUIwhscoe7CJIixMp6A3GyZyaKT87OSEnaJ7jXNRJrc1iCDa7rDptWSOcFWWCVqc9Hmqea4C7VJfSB73BwXFJ9P0R5goEhNN1kp9MJyT39wzK2mUY8txwYjg8yQPrk/vFVwVW4BJXe4BESKxHXUxAVVxLU9JMXV0hrFgv7eQKSwcfdFaYHe4RXcX5UYZVGOwhcGIx3Pzmn6esNhBrKIZukc9iWo5d2DLajN0OVFg1N8vTW3UyY5a5MfxkDNGHlqy5G4f4bd9jF4voWQ==,iv:hPIz4a71E2P/kgonGVjxX1Z+ABNPSmT8cEWFfQylKps=,tag:ixHfyBTl+0qinuBIR5koFw==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:d7Pr0Go9Mg==,iv:YywMeMaJiPE/IaQZvUyJJrpgPYwtQJpDEwZDfbEFu5c=,tag:eNQVxeaG+sb3+tq4tf22hQ==,type:int]
+            probability: ENC[AES256_GCM,data:FxXuVw==,iv:loZ/zZKUtlmEuFT6T8p3ZsXV7k1EQI095l5OKJI5mbk=,tag:0KgA+fVxZmtTZWBindx8aw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:0cyKdxlWOQ==,iv:ZBCDO0ghuvVg9Srf/M743UaQ6WLriktT/DRU8wR2Imc=,tag:hFP+zJcZFcSLQWooTJtK4w==,type:int]
+            probability: ENC[AES256_GCM,data:cw==,iv:4+sdItbbwDXmRFwLZYNOEY9rCdk49dAD4Stn5wsOCyw=,tag:omrJ563zRYdwtJwWFqP8zg==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:0qnCC3obbg==,iv:VTE6UEJG3GAtGcysjQxCNMsg1ORMpBg8JoNhspjn1Lw=,tag:2iyydTYWbMxwOp7iBwDnyw==,type:str]
+            - ENC[AES256_GCM,data:Sw5XOsyxONzIKjAw27xWKeg=,iv:eeINO1z6mWeHNWTVox30qaq+4QeLkPH1WlEkOAXtAIc=,tag:5M4YhvO6sb0Hit8FhDhEkA==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:w1D1UycxpHUuApkq5zCGQj7/67pDvmri,iv:Z1GH5UUn5Z8+pI46JrOLi4hNJQuKoQGeY6c+IQ1FfJQ=,tag:jNjnNcGzAKLEqctCtZYfjA==,type:str]
+            - ENC[AES256_GCM,data:AUWNQKFCszikRu1K7w==,iv:cC+bdYcsB4XiTzqR4HdDvBrfrP9VstC4WwaJQs2Uyug=,tag:UIoz6quG1hTWkFaTH/Dt/Q==,type:str]
+      title: ENC[AES256_GCM,data:88LdoVe/mSfxwrb/nqZLhZbJbT5DzNws/cGR5tZ1jNAYhhQN6qfYYAB7CnlEeU31TV6q0nkEd1DrfsiLNV7E8C/EIYuJMIG3Qhgbwq7MLAtwa2Ir/b/MCgB07BkpdrHrYaHM,iv:brCH7vfypb2O7kqo22IiecEVdgdBUYjm/2bAtkYpjks=,tag:Oj8AstaKcqpcPDWfoddlog==,type:str]
+sops:
+    shamir_threshold: 2
+    key_groups:
+        - gcp_kms:
+            - resource_id: projects/skvis-prod-9329/locations/europe-north1/keyRings/skvis-risc-key-ring/cryptoKeys/skvis-risc-crypto-key
+              created_at: "2025-02-19T13:07:18Z"
+              enc: CiQAikFTnPzClG2ANQeRnH0qFECbHd5NmNw8JicGZSTD2gmreAsSSgBdjvferjJ5I+t2uDqeefhWY/pWjdWhtC1KsagC97FnebPeEeFW6/aT8c7J+oS01PNMTMVGhbk0cJBbJiVWpmd9kCV79AeQ9N4p
+          hc_vault: []
+          age:
+            - recipient: age145s860ux96jvx6d7nwvzar588qjmgv5p47sp6nmmt2jnmhqh4scqcuk0mg
+              enc: |
+                -----BEGIN AGE ENCRYPTED FILE-----
+                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1TE9PRjFrZGlmMStyemNp
+                TmxkcnhQTDhHZWx6SHp4L0VvRURjaVNMbUNVCm10TjluMjJFL05uM1ZtTEdmM1Y5
+                TnZDT2FiN3c0U2RRcFNsMXNkcWhvaHMKLS0tIFJQdEdYR24xK29nUHhJejQ1WGZS
+                YkFYNDZILzNJeG5QZHJWbFpyZExyQmcKbgFRB5SIF2jcPDyw5Th//7MkPoxWc9hF
+                UsAXy6YGEOK8u9OfvyePxvV6Pyg1GKI2hE/mDeu7LPwCA6kZ5qQ7usU=
+                -----END AGE ENCRYPTED FILE-----
+        - hc_vault: []
+          age:
+            - recipient: age18e0t6ve0vdxqzzjt7rxf0r6vzc37fhs5cad2qz40r02c3spzgvvq8uxz23
+              enc: |
+                -----BEGIN AGE ENCRYPTED FILE-----
+                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjVmxUYXRlMjNWR2plOE5p
+                clNSTzMycnlpYmJYeEJXU2lCMkw4UGF4N1RFCjZGYWF0U3FvWXo4dWE3ZDlIeFdB
+                a1F2Ri9FNGVlMmdxWWIxWExSOXBML1kKLS0tIGFXNTFvblN2bmNWNU1JcFdpL0VK
+                UVM1WlBVdHFyenkrNXFxVER3MWRhSmcKGb5/nrXD3ouJVj3N6DbtLLFIGKc8uXvB
+                FFJRp2zXIZMItu9vIsXaj+2Z4QzrCRJetcxQEXeTvHiaFflHsrlEcjI=
+                -----END AGE ENCRYPTED FILE-----
+            - recipient: age1kjpgclkjev08aa8l2uy277gn0cngrkrkazt240405ezqywkm5axqt3d3tq
+              enc: |
+                -----BEGIN AGE ENCRYPTED FILE-----
+                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYNTEzeUd0QjIyc3Z2cytm
+                SStUT0ZOYkpXY29hNkVVRUYxTVQyaWY5MkZJCmtpc3cxdFZXaUN3MTFISXBmK05O
+                aWJlaS9RYlI1VW94NmFuQStsUDdTcW8KLS0tIDI3UnlGTGVldzhReUsveGZFMkhL
+                NERxNXRLRDFsTk04QTkxNHR0WlNibE0Kcn4DY4c8nWaa2G0oMX1TCOZeMyGPUWan
+                J/+4GXeNUb7wRJQ8/7mMSytcTF9VDJAvYPgEnDO9+GVPb4gQYZHOGRs=
+                -----END AGE ENCRYPTED FILE-----
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2025-02-19T13:07:22Z"
+    mac: ENC[AES256_GCM,data:DFM+cfj7tk4V0mvNqh318+/sFTcegPnUv0lfk1uAJ1my0j/M7mP7AZ8UgCr0GYjS4v6FHie79nqbHozIj6TEC2gu+iCR2+KtIV8TBQwQYjAHREtPruldXwCy+WWIQm+BDCjzyTbdOYSNUkjAw54ULBXXoePOYkuZuIfOeJn9vsA=,iv:KS5/xq01J10WvRRPXZK1sxPrjR8YBft65N9hQ3Ue/6s=,tag:u9WVkS8c+V+8UlKes5PNgw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.0

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "skvis"
   system: "ros-as-code"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_backstage-plugin-risk-crypto-service"
-  title: "Security Champion backstage-plugin-risk-crypto-service"
-spec:
-  type: "security_champion"
-  parent: "eiendom_security_champions"
-  members:
-  - "larsore"
-  children:
-  - "resource:backstage-plugin-risk-crypto-service"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "backstage-plugin-risk-crypto-service"
-  links:
-  - url: "https://github.com/kartverket/backstage-plugin-risk-crypto-service"
-    title: "backstage-plugin-risk-crypto-service på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_backstage-plugin-risk-crypto-service"
-  dependencyOf:
-  - "component:backstage-plugin-risk-crypto-service"


### PR DESCRIPTION
## Kort forklart
Denne PRen oppretter filene `.security/risc/.sops.yaml` og `.security\risc\risc-default.risc.yaml`.
I tillegg omdøpes `.sikkerhet/beskrivelse.yaml` til `.security/description.yaml`, og `CODEOWNERS` endres til at Security Champion får eierskap til `.security`. `.sikkerhet`-mappa skal dermed være tom, og derfor slettes den.
`catalog-info.yaml` oppdateres eventuelt til siste versjon, eller opprettes hvis den ikke finnes fra før.

- `.sops.yaml` inneholder nøklene som RiSc-filer skal krypteres med.
- `risc-default.risc.yaml` er den (krypterte) initielle risiko- og sårbarhetsanalysen (RoSen) for repoet basert på [sikkerhetsmetrikkene](https://kartverket.dev/catalog/default/component/backstage-plugin-risk-crypto-service/securityMetrics) og vanlige sikkerhetskontrollere.

RoSen kan leses og redigeres i [utviklerportalen](https://kartverket.dev/catalog/default/component/backstage-plugin-risk-crypto-service/risc/risc-default).
Det står mer om den initielle RoSen [her](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/1308065798/Initiell+RoS).

## Litt lenger forklart (hvorfor gjør vi dette?)
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet#Versjon-4.0%3A-Koden%C3%A6r-risiko--og-s%C3%A5rbarhetsanalyse-(RoS)).