### PR TITLE
Fix mapping of additional age keys in the encryption service

### DIFF
--- a/src/main/kotlin/cryptoservice/service/EncryptionService.kt
+++ b/src/main/kotlin/cryptoservice/service/EncryptionService.kt
@@ -52,7 +52,8 @@ class EncryptionService {
                     mapOf(
                         "age" to
                             config.age
-                                ?.filter { it.recipient !in setOf(securityTeamPublicKey, backendPublicKey, securityPlatformPublicKey) },
+                                ?.map { it.recipient }
+                                ?.filter { it !in setOf(securityTeamPublicKey, backendPublicKey, securityPlatformPublicKey) },
                     ),
                 )
 


### PR DESCRIPTION
Fixes an issue introduced in #84, where the additional age keys (for local changes) were incorrectly mapped before given as input to SOPS. The incorrect mapping results in YAML errors, as the resulting input file is not correctly formatted.