### PR TITLE
endepunktstester for kryptotjenesten

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,11 +76,9 @@ dependencies {
         exclude(group = "org.mockito")
     }
 
-
     sharedTestImplementation("org.springframework.boot:spring-boot-starter-test")
     sharedTestImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     sharedTestRuntimeOnly("org.junit.platform:junit-platform-launcher")
-
 
     smokeTestImplementation("org.springframework.boot:spring-boot-starter-webflux")
     smokeTestImplementation("org.testcontainers:testcontainers:$testcontainersVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,9 +70,17 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$fasterXmlJacksonVersion")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$fasterXmlJacksonVersion")
 
+    testImplementation("io.mockk:mockk:1.13.7")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        exclude(group = "org.mockito")
+    }
+
+
     sharedTestImplementation("org.springframework.boot:spring-boot-starter-test")
     sharedTestImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     sharedTestRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
 
     smokeTestImplementation("org.springframework.boot:spring-boot-starter-webflux")
     smokeTestImplementation("org.testcontainers:testcontainers:$testcontainersVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,9 +72,6 @@ dependencies {
 
     testImplementation("io.mockk:mockk:1.13.7")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
-    testImplementation("org.springframework.boot:spring-boot-starter-test") {
-        exclude(group = "org.mockito")
-    }
 
     sharedTestImplementation("org.springframework.boot:spring-boot-starter-test")
     sharedTestImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -47,9 +47,7 @@ class CryptoControllerTest {
             RiScWithConfig(
                 riSc = "decrypted-data",
                 sopsConfig =
-                    SopsConfig(
-                        shamir_threshold = 1,
-                    ),
+                    SopsConfig(),
             )
 
         every {
@@ -71,7 +69,6 @@ class CryptoControllerTest {
                     .contentType(MediaType.APPLICATION_JSON),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.riSc").value("decrypted-data"))
-            .andExpect(jsonPath("$.sopsConfig.shamir_threshold").value(1))
     }
 
     @Test
@@ -86,17 +83,7 @@ class CryptoControllerTest {
                 shamir_threshold = 1,
             )
 
-        val requestJson =
-            """
-            {
-                "text": "$plaintext",
-                "config": {
-                    "shamir_threshold": 1
-                },
-                "gcpAccessToken": "$gcpToken",
-                "riScId": "$riScId"
-            }
-            """.trimIndent()
+        val requestJson = buildEncryptionRequestJson(plaintext, 1, gcpToken, riScId)
 
         every {
             encryptionService.encrypt(
@@ -163,17 +150,7 @@ class CryptoControllerTest {
         val gcpToken = "token123"
         val riScId = "risc-id-123"
 
-        val requestJson =
-            """
-            {
-                "text": "$plaintext",
-                "config": {
-                    "shamir_threshold": 1
-                },
-                "gcpAccessToken": "$gcpToken",
-                "riScId": "$riScId"
-            }
-            """.trimIndent()
+        val requestJson = buildEncryptionRequestJson(plaintext, 1, gcpToken, riScId)
 
         every {
             encryptionService.encrypt(
@@ -191,4 +168,21 @@ class CryptoControllerTest {
                     .content(requestJson),
             ).andExpect(status().isInternalServerError)
     }
+
+    private fun buildEncryptionRequestJson(
+        text: String,
+        shamirThreshold: Int,
+        gcpAccessToken: String,
+        riScId: String,
+    ): String =
+        """
+        {
+            "text": "$text",
+            "config": {
+                "shamir_threshold": $shamirThreshold
+            },
+            "gcpAccessToken": "$gcpAccessToken",
+            "riScId": "$riScId"
+        }
+        """.trimIndent()
 }

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -1,5 +1,6 @@
 package cryptoservice.controller
 
+import com.ninjasquad.springmockk.MockkBean
 import cryptoservice.model.GCPAccessToken
 import cryptoservice.model.RiScWithConfig
 import cryptoservice.model.SopsConfig
@@ -11,22 +12,20 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
-import com.ninjasquad.springmockk.MockkBean
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(CryptoController::class)
 @AutoConfigureMockMvc
 @TestPropertySource(
-    properties = ["sops.ageKey=test-age-key"] //ha denne med? eller hente fra application.properties?
+    properties = ["sops.ageKey=test-age-key"], // ha denne med? eller hente fra application.properties?
 )
-
-class CryptoControllerTest() {
-
+class CryptoControllerTest {
     @Autowired
     lateinit var mockMvc: MockMvc
 
@@ -44,39 +43,103 @@ class CryptoControllerTest() {
         val cipherText = "ENC[encrypted]"
         val token = "token123"
 
-        val expected = RiScWithConfig(
-            riSc = "decrypted-data",
-            sopsConfig = SopsConfig(
-                shamir_threshold = 1,
-                version = "3.7.3" //trenger strengt tatt ikke ha med denne
+        val expected =
+            RiScWithConfig(
+                riSc = "decrypted-data",
+                sopsConfig =
+                    SopsConfig(
+                        shamir_threshold = 1,
+                        version = "3.7.3", // trenger strengt tatt ikke ha med denne
+                    ),
             )
-        )
 
-        println("sopsAgePrivateKey = '$sopsAgePrivateKey'")
         every {
             decryptionService.decryptWithSopsConfig(
-                ciphertext = match {
-                    println("ACTUAL ciphertext: '$it'")
-                    it.trim('"') == cipherText
-                },
+                ciphertext =
+                    match {
+                        it.trim('"') == cipherText
+                    },
                 gcpAccessToken = eq(GCPAccessToken(token)),
-                sopsAgeKey = eq(sopsAgePrivateKey)
+                sopsAgeKey = eq(sopsAgePrivateKey),
             )
         } returns expected
 
-        mockMvc.perform(
-            post("/decrypt")
-                .header("gcpAccessToken", token)
-                .content("\"$cipherText\"")
-                .contentType(MediaType.APPLICATION_JSON)
-        )
-            .andDo { result ->
+        mockMvc
+            .perform(
+                post("/decrypt")
+                    .header("gcpAccessToken", token)
+                    .content("\"$cipherText\"")
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andDo { result ->
                 println("Response body: ${result.response.contentAsString}")
-            }
-
-            .andExpect(status().isOk)
+            }.andExpect(status().isOk)
             .andExpect(jsonPath("$.riSc").value("decrypted-data"))
             .andExpect(jsonPath("$.sopsConfig.version").value("3.7.3"))
+    }
+
+    @Test
+    fun `should return encrypted string on successful encrypt`() {
+        val plaintext = "some-secret"
+        val encrypted = "ENC[encrypted]"
+        val gcpToken = "token123"
+        val riScId = "risc-id-123"
+
+        val config =
+            SopsConfig(
+                shamir_threshold = 1,
+            )
+
+        val requestJson =
+            """
+            {
+                "text": "$plaintext",
+                "config": {
+                    "shamir_threshold": 1
+                },
+                "gcpAccessToken": "$gcpToken",
+                "riScId": "$riScId"
+            }
+            """.trimIndent()
+
+        every {
+            encryptionService.encrypt(
+                eq(plaintext),
+                eq(config),
+                eq(GCPAccessToken(gcpToken)),
+                eq(riScId),
+            )
+        } returns encrypted
+
+        mockMvc
+            .perform(
+                post("/encrypt")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestJson),
+            ).andExpect(status().isOk)
+            .andExpect(content().string(encrypted))
+    }
+
+    @Test
+    fun `should return 400 when decrypt request body is missing`() {
+        mockMvc
+            .perform(
+                post("/decrypt")
+                    .header("gcpAccessToken", "token123")
+                    .content("")
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when encryption request is invalid`() {
+        val invalidJson = "{}"
+
+        mockMvc
+            .perform(
+                post("/encrypt")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidJson),
+            ).andExpect(status().isBadRequest)
     }
 
     @Test
@@ -88,53 +151,13 @@ class CryptoControllerTest() {
             decryptionService.decryptWithSopsConfig(any(), any(), any())
         } throws RuntimeException("mocked failure")
 
-        mockMvc.perform(
-            post("/decrypt")
-                .header("gcpAccessToken", token)
-                .content("\"$cipherText\"")
-                .contentType(MediaType.APPLICATION_JSON)
-        )
-            .andExpect(status().isInternalServerError)
-    }
-
-    @Test
-    fun `should return encrypted string on successful encrypt`() {
-        val plaintext = "some-secret"
-        val encrypted = "ENC[encrypted]"
-        val gcpToken = "token123"
-        val riScId = "risc-id-123"
-
-        val config = SopsConfig(
-            shamir_threshold = 1
-        )
-
-        val requestJson = """
-        {
-            "text": "$plaintext",
-            "config": {
-                "shamir_threshold": 1
-            },
-            "gcpAccessToken": "$gcpToken",
-            "riScId": "$riScId"
-        }
-    """.trimIndent()
-
-        every {
-            encryptionService.encrypt(
-                eq(plaintext),
-                eq(config),
-                eq(GCPAccessToken(gcpToken)),
-                eq(riScId)
-            )
-        } returns encrypted
-
-        mockMvc.perform(
-            post("/encrypt")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestJson)
-        )
-            .andExpect(status().isOk)
-            .andExpect(content().string(encrypted))
+        mockMvc
+            .perform(
+                post("/decrypt")
+                    .header("gcpAccessToken", token)
+                    .content("\"$cipherText\"")
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isInternalServerError)
     }
 
     @Test
@@ -143,34 +166,32 @@ class CryptoControllerTest() {
         val gcpToken = "token123"
         val riScId = "risc-id-123"
 
-        val config = SopsConfig(
-            shamir_threshold = 1
-        )
-
-        val requestJson = """
-        {
-            "text": "$plaintext",
-            "config": {
-                "shamir_threshold": 1
-            },
-            "gcpAccessToken": "$gcpToken",
-            "riScId": "$riScId"
-        }
-    """.trimIndent()
+        val requestJson =
+            """
+            {
+                "text": "$plaintext",
+                "config": {
+                    "shamir_threshold": 1
+                },
+                "gcpAccessToken": "$gcpToken",
+                "riScId": "$riScId"
+            }
+            """.trimIndent()
 
         every {
             encryptionService.encrypt(
-                any(), any(), any(), any()
+                any(),
+                any(),
+                any(),
+                any(),
             )
         } throws RuntimeException("mocked encryption failure")
 
-        mockMvc.perform(
-            post("/encrypt")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestJson)
-        )
-            .andExpect(status().isInternalServerError)
+        mockMvc
+            .perform(
+                post("/encrypt")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestJson),
+            ).andExpect(status().isInternalServerError)
     }
 }
-
-//TODO: legge til tester for 400 bad request

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -128,7 +128,7 @@ class CryptoControllerTest {
     }
 
     @Test
-    fun `should return 400 when encryption request is invalid`() {
+    fun `should return 400 when encryption request body is invalid`() {
         val invalidJson = "{}"
 
         mockMvc

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -73,6 +73,7 @@ class CryptoControllerTest {
                 println("Response body: ${result.response.contentAsString}")
             }.andExpect(status().isOk)
             .andExpect(jsonPath("$.riSc").value("decrypted-data"))
+            .andExpect(jsonPath("$.sopsConfig.shamir_threshold").value(1))
     }
 
     @Test

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @WebMvcTest(CryptoController::class)
 @AutoConfigureMockMvc
 @TestPropertySource(
-    properties = ["sops.ageKey=test-age-key"], // ha denne med? eller hente fra application.properties?
+    properties = ["sops.ageKey=test-age-key"],
 )
 class CryptoControllerTest {
     @Autowired
@@ -49,7 +49,6 @@ class CryptoControllerTest {
                 sopsConfig =
                     SopsConfig(
                         shamir_threshold = 1,
-                        version = "3.7.3", // trenger strengt tatt ikke ha med denne
                     ),
             )
 
@@ -74,7 +73,6 @@ class CryptoControllerTest {
                 println("Response body: ${result.response.contentAsString}")
             }.andExpect(status().isOk)
             .andExpect(jsonPath("$.riSc").value("decrypted-data"))
-            .andExpect(jsonPath("$.sopsConfig.version").value("3.7.3"))
     }
 
     @Test

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -76,7 +76,7 @@ class CryptoControllerTest {
     }
 
     @Test
-    fun `should return encrypted string on successful encrypt`() {
+    fun `should encrypt plaintext with valid token`() {
         val plaintext = "some-secret"
         val encrypted = "ENC[encrypted]"
         val gcpToken = "token123"

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -79,6 +79,46 @@ class CryptoControllerTest() {
             .andExpect(jsonPath("$.riSc").value("decrypted-data"))
             .andExpect(jsonPath("$.sopsConfig.version").value("3.7.3"))
     }
+
+    @Test
+    fun `should return 500 when decryption fails`() {
+        val cipherText = "ENC[invalid]"
+        val token = "token123"
+
+        every {
+            decryptionService.decryptWithSopsConfig(any(), any(), any())
+        } throws RuntimeException("mocked failure")
+
+        mockMvc.perform(
+            post("/decrypt")
+                .header("gcpAccessToken", token)
+                .content("\"$cipherText\"")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isInternalServerError)
+    }
+
+    @Test
+    fun `should return encrypted string on successful encrypt`() {
+        val plaintext = "some-secret"
+        val encrypted = "ENC[encrypted]"
+
+        every { encryptionService.encrypt(eq(plaintext)) } returns encrypted //TODO: se på encrypt endepunkt
+
+        mockMvc.perform(
+            post("/encrypt")
+                .content("\"$plaintext\"")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().string("\"$encrypted\""))
+    }
+
+    //Test 2: Feilende decrypt – f.eks. ugyldig token
+
+    //Test 3: Feilende decrypt – generisk exception
+
+    //Test 4: encrypt: should return encrypted string on successful encrypt
 }
 
         // én fail

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -1,0 +1,108 @@
+package cryptoservice.controller
+
+import cryptoservice.model.GCPAccessToken
+import cryptoservice.model.RiScWithConfig
+import cryptoservice.model.SopsConfig
+import cryptoservice.service.DecryptionService
+import cryptoservice.service.EncryptionService
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+
+//@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) //starter spring-applikasjonen
+//inkludert controllere. må ha den for å ha et endepunkt å kalle
+@WebMvcTest(CryptoController::class)
+@AutoConfigureMockMvc //setter opp en mockMvc automatisk
+@TestPropertySource(
+    properties = [
+        "sops.ageKey=test-age-key",
+        "sops.decryption.backendPublicKey=dummy-backend",
+        "sops.decryption.securityTeamPublicKey=dummy-team",
+        "sops.decryption.securityPlatformPublicKey=dummy-platform"
+    ]
+)
+
+class CryptoControllerTest() {
+
+    @Autowired //initialiserer webtestclient
+    lateinit var mockMvc: MockMvc // ønsker en webtestclient koblet til applikasjonen når jeg starter testen
+
+    //TODO: bruke denne eller ReplaceWithMock? hvilken spring boot versjon brukes og skal det oppdateres snart?
+
+    @MockBean
+    lateinit var decryptionService: DecryptionService
+
+    @MockBean
+    lateinit var encryptionService: EncryptionService
+
+    @Value("\${sops.ageKey}") //dummy variabel definert over
+    lateinit var sopsAgePrivateKey: String
+
+    // teste decrypt endepunktet
+    // én success
+    @Test
+    //fun `should return 200 ok and decrypted object`() { // TODO: kanskje endre navn på testen
+    fun `should return RiscWithConfig object on successful decrypt`() { //funker dette?
+        val cipherText = "ENC[encrypted]"
+        val token = "token123"
+
+        val expected = RiScWithConfig(
+            riSc = "decrypted-data",
+            sopsConfig = SopsConfig(
+                shamir_threshold = 1
+                //gcp_kms = emptyList(),
+                //version = "3.7.3"
+            )
+        )
+
+        `when`(
+            decryptionService.decryptWithSopsConfig(
+                ciphertext = cipherText,
+                gcpAccessToken = GCPAccessToken(token),
+                sopsAgeKey = sopsAgePrivateKey
+            )
+        ).thenReturn(expected)
+
+        mockMvc.perform(
+            post("/decrypt")
+                .header("gcpAccessToken", token)
+                .content("\"$cipherText\"")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andDo { result ->
+                println("Response body: ${result.response.contentAsString}")
+            }
+
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.risc").value("decrypted-data"))
+            //.andExpect(jsonPath("$.sopsConfig.version").value("3.7.3"))
+    }
+}
+
+                // Arrange
+
+                // Act
+                // Assert
+
+        // én fail
+        //@Test
+        //fun `should return 200 ok and decrypted object`() {
+
+       // }
+
+    // teste encrypt endepunktet
+        // én success
+        // én fail
+
+

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -39,7 +39,7 @@ class CryptoControllerTest {
     lateinit var sopsAgePrivateKey: String
 
     @Test
-    fun `should return RiscWithConfig object on successful decrypt`() {
+    fun `should decrypt with valid token and ciphertext`() {
         val cipherText = "ENC[encrypted]"
         val token = "token123"
 

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -69,9 +69,7 @@ class CryptoControllerTest {
                     .header("gcpAccessToken", token)
                     .content("\"$cipherText\"")
                     .contentType(MediaType.APPLICATION_JSON),
-            ).andDo { result ->
-                println("Response body: ${result.response.contentAsString}")
-            }.andExpect(status().isOk)
+            ).andExpect(status().isOk)
             .andExpect(jsonPath("$.riSc").value("decrypted-data"))
             .andExpect(jsonPath("$.sopsConfig.shamir_threshold").value(1))
     }


### PR DESCRIPTION
### Lagt til endepunktstester for CryptoController:

**Decrypt-endepunkt:**
- Returnerer 200 OK med riktig RiScWithConfig når decrypt lykkes
- Returnerer 500 Internal Server Error når decrypt feiler
- Returnerer 400 Bad Request ved ugyldig eller manglende request body

**Encrypt-endepunkt:**
- Returnerer 200 OK med forventet kryptert streng når encrypt lykkes
- Returnerer 500 Internal Server Error når encrypt feiler
- Returnerer 400 Bad Request ved ugyldig request body

TODO: Fjerne -x test fra ./gradlew build i CI-workflowen for at testene kjøres automatisk ved PR og før deploy??