### PR TITLE
Cleanup dependency declarations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ val smokeTestRuntimeOnly: Configuration by configurations.getting {
     extendsFrom(configurations.getByName("sharedTestRuntimeOnly"))
 }
 
+val springBootVersion = "3.4.5"
 val fasterXmlJacksonVersion = "2.19.0"
 val testcontainersVersion = "1.21.0"
 val micrometerVersion = "1.14.6"
@@ -65,8 +66,8 @@ val springMockkVersion = "4.0.2"
 val junitVersion = "5.12.2"
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+    implementation("org.springframework.boot:spring-boot-starter-actuator:$springBootVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion") {
         because("Provides endpoints for health and event monitoring that are used in SKIP.")
@@ -81,7 +82,7 @@ dependencies {
     testImplementation("io.mockk:mockk:$mockkVersion")
     testImplementation("com.ninja-squad:springmockk:$springMockkVersion")
 
-    sharedTestImplementation("org.springframework.boot:spring-boot-starter-test")
+    sharedTestImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
 
     platform("org.junit:junit-bom:$junitVersion") {
         because("The BOM (bill of materials) provides correct versions for all JUnit libraries used.")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,6 @@ val smokeTestRuntimeOnly: Configuration by configurations.getting {
 }
 
 val fasterXmlJacksonVersion = "2.19.0"
-val kotlinxSerializationVersion = "1.7.3"
 val testcontainersVersion = "1.21.0"
 val micrometerVersion = "1.14.6"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ val testcontainersVersion = "1.21.0"
 val micrometerVersion = "1.14.6"
 val mockkVersion = "1.14.0"
 val springMockkVersion = "4.0.2"
+val junitVersion = "5.12.2"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -81,6 +82,10 @@ dependencies {
     testImplementation("com.ninja-squad:springmockk:$springMockkVersion")
 
     sharedTestImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    platform("org.junit:junit-bom:$junitVersion") {
+        because("The BOM (bill of materials) provides correct versions for all JUnit libraries used.")
+    }
     sharedTestImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     sharedTestRuntimeOnly("org.junit.platform:junit-platform-launcher")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,8 @@ val smokeTestRuntimeOnly: Configuration by configurations.getting {
 val fasterXmlJacksonVersion = "2.19.0"
 val testcontainersVersion = "1.21.0"
 val micrometerVersion = "1.14.6"
+val mockkVersion = "1.14.0"
+val springMockkVersion = "4.0.2"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -75,8 +77,8 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 
-    testImplementation("io.mockk:mockk:1.14.0")
-    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("io.mockk:mockk:$mockkVersion")
+    testImplementation("com.ninja-squad:springmockk:$springMockkVersion")
 
     sharedTestImplementation("org.springframework.boot:spring-boot-starter-test")
     sharedTestImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
     sharedTestImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     sharedTestRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    smokeTestImplementation("org.springframework.boot:spring-boot-starter-webflux")
+    smokeTestImplementation("org.springframework.boot:spring-boot-starter-webflux:$springBootVersion")
     smokeTestImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,6 @@ val junitVersion = "5.12.2"
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
     implementation("org.springframework.boot:spring-boot-starter-actuator:$springBootVersion")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion") {
         because("Provides endpoints for health and event monitoring that are used in SKIP.")
     }


### PR DESCRIPTION
Cleans up dependency declarations in `build.gradle.kts`:
- Specify versions where missing
- Use variables for all version declarations
- Remove unused `kotlin-reflect` dependency
- Use JUnit BOM for version management for JUnit dependencies