### PR TITLE
Add health check in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,3 +42,7 @@ USER user
 
 EXPOSE 8080 8081
 ENTRYPOINT ["java", "-jar", "/app/backend.jar"]
+
+# Use the health endpoint of the application to provide information through docker about the health state of the application
+HEALTHCHECK --start-period=30s --start-interval=10s --interval=5m \
+    CMD wget -O - --quiet --tries=1 http://localhost:8083/actuator/health | grep UP || exit 1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
     implementation("org.springframework.boot:spring-boot-starter-actuator:$springBootVersion")
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion") {
-        because("Provides endpoints for health and event monitoring that are used in SKIP.")
+        because("Provides endpoints for health and event monitoring that are used in SKIP and Docker.")
     }
 
     implementation("com.fasterxml.jackson:jackson-bom:$fasterXmlJacksonVersion") {


### PR DESCRIPTION
Adds a health check to the docker container, to allow docker to know if the application is healthy.

Fixes [code scanning issue 177](https://github.com/kartverket/backstage-plugin-risk-crypto-service/security/code-scanning/177).