### PR TITLE
Add permissions to the add-issue-to-project workflow.

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -3,6 +3,9 @@ name: Add all issues to Sikkerhetsmetrikker project
 on:
   issues:
 
+permissions:
+  issues: read
+
 jobs:
   add-to-project:
     name: Add issue to project


### PR DESCRIPTION
Restricts the permissions of the `add-issue-to-project` workflow to reading issues. The workflow reads issue and mirrors them to an external project. Thus, it does not require any more permissions in this repository.

Fixes [code scanning issue 134](https://github.com/kartverket/backstage-plugin-risk-crypto-service/security/code-scanning/134).