### PR TITLE
fix: bump Spring Boot version to 4.0.2

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -106,10 +106,14 @@ jobs:
         run: |
           set -euo pipefail
           for i in {1..30}; do
-          [ "$(curl -fsS http://localhost:8081/actuator/health || true)" = '{"status":"UP"}' ] && {
-              echo "✅ Status UP"; exit 0; }
-            echo "Waiting for status UP"; sleep 2
-          done
+            STATUS="$(curl -fsS http://localhost:8081/actuator/health | jq -r '.status' 2>/dev/null || true)"
+            if [ "$STATUS" = "UP" ]; then
+              echo "✅ Status UP"
+              exit 0
+            fi
+            echo "Waiting for status UP (got: ${STATUS:-<no response>})"
+              sleep 2
+            done
           echo "❌ Container failed to become healthy"
           docker logs ${{ github.run_id }} || true
           exit 1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion") {
         because("Provides endpoints for health and event monitoring that are used in SKIP and Docker.")
     }
+    implementation("org.springframework.boot:spring-boot-starter-webmvc-test")
 
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion") {
         because("Auto-generates OpenAPI 3.0 specification and provides Swagger UI for API documentation.")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
 }
 
+// Override the AssertJ version managed by Spring Boot to mitigate CVE-2026-24400
+ext["assertj.version"] = "3.27.7"
+
 // Specifies the usage of the currently newest version of Ktlint. `org.jlleitschuh.gradle.ktlint` version 14.0.1 is
 // not guaranteed to use the newest version available.
 ktlint {
@@ -100,7 +103,7 @@ dependencies {
     testImplementation("io.mockk:mockk:$mockkVersion")
     testImplementation("com.ninja-squad:springmockk:$springMockkVersion")
 
-    sharedTestImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
+    sharedTestImplementation("org.springframework.boot:spring-boot-starter-test")
 
     platform("org.junit:junit-bom:$junitVersion") {
         because("The BOM (bill of materials) provides correct versions for all JUnit libraries used.")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "3.5.10"
+    id("org.springframework.boot") version "4.0.2"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("jvm") version "2.3.0"
     kotlin("plugin.spring") version "2.3.0"
@@ -57,7 +57,7 @@ val smokeTestRuntimeOnly: Configuration by configurations.getting {
     extendsFrom(configurations.getByName("sharedTestRuntimeOnly"))
 }
 
-val springBootVersion = "3.5.10"
+val springBootVersion = "4.0.2"
 val fasterXmlJacksonVersion = "2.21.0"
 val testcontainersVersion = "2.0.3"
 val micrometerVersion = "1.16.2"
@@ -71,6 +71,7 @@ dependencies {
         exclude(group = "ch.qos.logback", module = "logback-core")
         exclude(group = "ch.qos.logback", module = "logback-classic")
     }
+    implementation("org.springframework.boot:spring-boot-health:$springBootVersion")
     implementation("org.springframework.boot:spring-boot-starter-actuator:$springBootVersion") {
         exclude(group = "ch.qos.logback", module = "logback-core")
         exclude(group = "ch.qos.logback", module = "logback-classic")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion") {
         because("Provides endpoints for health and event monitoring that are used in SKIP and Docker.")
     }
-    implementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
 
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion") {
         because("Auto-generates OpenAPI 3.0 specification and provides Swagger UI for API documentation.")

--- a/src/main/kotlin/cryptoservice/health/SopsHealthIndicator.kt
+++ b/src/main/kotlin/cryptoservice/health/SopsHealthIndicator.kt
@@ -1,8 +1,8 @@
 package cryptoservice.health
 
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.actuate.health.Health
-import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.stereotype.Component
 import java.io.BufferedReader
 import java.io.InputStreamReader

--- a/src/main/kotlin/cryptoservice/service/Utils.kt
+++ b/src/main/kotlin/cryptoservice/service/Utils.kt
@@ -26,13 +26,13 @@ object YamlUtils {
     val objectMapper =
         ObjectMapper(yamlFactory)
             .registerKotlinModule()
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
 
     inline fun <reified T> deSerialize(yamlString: String) = objectMapper.readValue(yamlString, T::class.java)
 
     fun <T> serialize(t: T) =
         ObjectMapper(yamlFactory.enable(YAMLGenerator.Feature.LITERAL_BLOCK_STYLE))
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
             .registerKotlinModule()
             .writeValueAsString(t)
 }

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -10,8 +10,8 @@ import io.mockk.every
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc

--- a/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
+++ b/src/test/kotlin/cryptoservice/controller/CryptoControllerTest.kt
@@ -10,8 +10,8 @@ import io.mockk.every
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
@@ -78,17 +78,12 @@ class CryptoControllerTest {
         val gcpToken = "token123"
         val riScId = "risc-id-123"
 
-        val config =
-            SopsConfig(
-                shamir_threshold = 1,
-            )
-
         val requestJson = buildEncryptionRequestJson(plaintext, 1, gcpToken, riScId)
 
         every {
             encryptionService.encrypt(
                 eq(plaintext),
-                eq(config),
+                any(), // Match any SopsConfig since JSON deserialization produces null fields
                 eq(GCPAccessToken(gcpToken)),
                 eq(riScId),
             )


### PR DESCRIPTION
# 📝 Beskrivelse

[Oppgave i Notion](https://www.notion.so/bekks/Oppdatere-SpringBoot-i-backend-crypto-til-v4-2e16bd30854180edbb9bdca7d3de4f30?source=copy_link)

Oppgradert til spring boot versjon 4.0.2.
Testet ved å kjøre docker-compose up og ting funker lokalt. Sjekk gjerne dette ut selv!


---

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [x] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
