### PR TITLE
fix: enhance error handling with descriptive error codes in decryption and encryption exceptions

### DIFF
--- a/src/main/kotlin/cryptoservice/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/cryptoservice/exception/GlobalExceptionHandler.kt
@@ -4,41 +4,51 @@ import cryptoservice.exception.exceptions.SOPSDecryptionException
 import cryptoservice.exception.exceptions.SopsEncryptionException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.ErrorResponse
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 
 @ControllerAdvice
 class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler
-    fun handleUncaughtException(
-        ex: Exception,
-        request: WebRequest,
-    ): ResponseEntity<ErrorResponse> {
+    fun handleUncaughtException(ex: Exception): ResponseEntity<Map<String, Any?>> {
         logger.warn(ex.message, ex)
+        val body =
+            mapOf(
+                "errorMessage" to (ex.message ?: "An unexpected error occurred"),
+                "errorCode" to "INTERNAL_SERVER_ERROR",
+            )
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ErrorResponse.create(ex, HttpStatus.INTERNAL_SERVER_ERROR, "Exception message: ${ex.message}"))
+            .body(body)
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(SopsEncryptionException::class)
-    fun handleSopsEncryptionException(ex: SopsEncryptionException): ResponseEntity<ErrorResponse> {
+    fun handleSopsEncryptionException(ex: SopsEncryptionException): ResponseEntity<Map<String, Any?>> {
         logger.error(ex.message, ex)
+        val body =
+            mapOf(
+                "errorMessage" to ex.message,
+                "errorCode" to ex.errorCode,
+            )
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ErrorResponse.create(ex, HttpStatus.INTERNAL_SERVER_ERROR, "Exception message: ${ex.message}"))
+            .body(body)
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(SOPSDecryptionException::class)
-    fun handleSopsDecryptionException(ex: SOPSDecryptionException): ResponseEntity<ErrorResponse> {
+    fun handleSopsDecryptionException(ex: SOPSDecryptionException): ResponseEntity<Map<String, Any?>> {
         logger.error(ex.message, ex)
+        val body =
+            mapOf(
+                "errorMessage" to ex.message,
+                "errorCode" to ex.errorCode,
+            )
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ErrorResponse.create(ex, HttpStatus.INTERNAL_SERVER_ERROR, "Exception message: ${ex.message}"))
+            .body(body)
     }
 }

--- a/src/main/kotlin/cryptoservice/exception/exceptions/SopsEncryptionException.kt
+++ b/src/main/kotlin/cryptoservice/exception/exceptions/SopsEncryptionException.kt
@@ -3,8 +3,10 @@ package cryptoservice.exception.exceptions
 data class SopsEncryptionException(
     override val message: String,
     val riScId: String,
+    val errorCode: String? = null,
 ) : Exception()
 
 data class SOPSDecryptionException(
     override val message: String,
+    val errorCode: String? = null,
 ) : Exception()


### PR DESCRIPTION
# 📝 Beskrivelse

[Oppgave i Notion](https://www.notion.so/bekks/Vise-riktig-feilmeldinger-basert-p-den-spesifikke-statusen-i-UI-3056bd30854180fba01ed7c250538f06?source=copy_link)

Oppdatert ExceptionHandling for å gi tydeligere tilbakemeldinger til brukere på hvorfor decryptering feiler. Dette blir sendt videre til backend som håndterer det og sender det videre til frontend.

**NB:** Må kjøres sammen med backend og frontend for testing. Husk å bygge container på nytt!
Se [frontend-PR](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/pull/897) for illustrasjonsbilder

---

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [x] [Test-sjekklisten i front-end repoet](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig (om relevant for endringen).
